### PR TITLE
Messages for file upload errors and cancel

### DIFF
--- a/group_project_v2/public/css/group_project.css
+++ b/group_project_v2/public/css/group_project.css
@@ -188,6 +188,7 @@
 }
 
 .message .message_title.error {
+    text-align: left;
     color: #E37222;
 }
 

--- a/group_project_v2/public/js/components/submission.js
+++ b/group_project_v2/public/js/components/submission.js
@@ -103,8 +103,16 @@ function GroupProjectSubmissionBlock(runtime, element) {
         fail: function (e, data) {
             var target_form = $(e.target);
             $('.' + data.paramName[0] + '_progress', target_form).css('width', '100%').addClass('failed');
-            var message = getMessageFromJson(data.jqXHR),
+            var message, title;
+            if (data.jqXHR.status === 0 && data.jqXHR.statusText === 'abort') {
+                title = gettext('Upload cancelled.');
+                message = gettext("Upload cancelled by user.");
+            }
+            else {
+                message = getMessageFromJson(data.jqXHR);
                 title = getMessageTitleFromJson(data.jqXHR, gettext("Error"));
+            }
+
             target_form.prop('title', message);
             show_message(message, title, 'error');
         }

--- a/group_project_v2/stage_components.py
+++ b/group_project_v2/stage_components.py
@@ -212,10 +212,12 @@ class GroupProjectSubmissionXBlock(
     STAGE_CLOSED_TEMPLATE = _(u"Can't {action} as stage is closed.")
 
     SUCCESSFUL_UPLOAD_TITLE = _(u"Upload complete.")
+    FAILED_UPLOAD_TITLE = _(u"Upload failed.")
     SUCCESSFUL_UPLOAD_MESSAGE_TPL = _(
         u"Your deliverable have been successfully uploaded. You can attach an updated version of the "
         u"deliverable by clicking the <span class='icon {icon}'></span> icon at any time before the deadline passes."
     )
+    FAILED_UPLOAD_MESSAGE_TPL = _(u"Error uploading file: {error_goes_here}")
 
     SUBMISSION_RECEIVED_EVENT = "activity.received_submission"
 
@@ -303,9 +305,12 @@ class GroupProjectSubmissionXBlock(
                 failure_code = 500
                 if isinstance(exception, ApiError):
                     failure_code = exception.code
-                if not hasattr(exception, "message"):
-                    exception.message = _("Error uploading at least one file")
-                response_data.update({"message": exception.message})
+                error_message = getattr(exception, "message", _(u"Unknown error"))
+
+                response_data.update({
+                    "title": self.FAILED_UPLOAD_TITLE,
+                    "message": self.FAILED_UPLOAD_MESSAGE_TPL.format(error_goes_here=error_message)
+                })
 
         response = webob.response.Response(body=json.dumps(response_data))
         if failure_code:

--- a/tests/unit/test_stage_components.py
+++ b/tests/unit/test_stage_components.py
@@ -184,8 +184,8 @@ class TestGroupProjectSubmissionXBlock(StageComponentXBlockTestBase):
 
     @ddt.data(
         (Exception("exception message"), 500),
-        (make_api_error(419, "other message"), 419),
-        (make_api_error(403, "yet another message"), 403),
+        (make_api_error(418, "other message"), 418),
+        (make_api_error(401, "yet another message"), 401),
     )
     @ddt.unpack
     def test_upload_submission_persist_and_submit_file_raises(self, exception, expected_code):
@@ -203,7 +203,11 @@ class TestGroupProjectSubmissionXBlock(StageComponentXBlockTestBase):
             response = self.block.upload_submission(request_mock)
             self.assertEqual(response.status_code, expected_code)
             response_body = json.loads(response.body)
-            self.assertEqual(response_body['message'], exception.message)
+            self.assertEqual(response_body['title'], GroupProjectSubmissionXBlock.FAILED_UPLOAD_TITLE)
+            self.assertEqual(
+                response_body['message'],
+                GroupProjectSubmissionXBlock.FAILED_UPLOAD_MESSAGE_TPL.format(error_goes_here=exception.message)
+            )
 
     @ddt.data(
         ("sub1", "file.html", "new_stage_state1"),


### PR DESCRIPTION
When user tries uploading a file, if upload is cancelled or failed, non-descriptive "Error" message is shown. This PR fixes passing error messages in case of failed upload and set's up proper message if user have cancelled the upload.

To test:

1. Try uploading the file with some illegal characters in a name (not sure what characters are exactly illegal, but `~` in file name proved to fail the upload).
2. Try cancelling the upload. Cancel button only appears during file upload at the very bottom of the PN. So, to actually use it, big file is needed (I use pycharm tarball - ~140Mb).