### PR TITLE
Styling fixes

### DIFF
--- a/group_project_v2/group_project.py
+++ b/group_project_v2/group_project.py
@@ -95,9 +95,10 @@ class GroupProjectXBlock(
         fragment = Fragment()
         render_context = {
             'project': self,
+            'course_id': self.course_id,
+            'group_id': self.workgroup['id']
         }
 
-        render_context = {'project': self}
         render_context.update(context)
 
         def render_child_fragment(child, content_key, fallback_message):

--- a/group_project_v2/public/css/components/project_team.css
+++ b/group_project_v2/public/css/components/project_team.css
@@ -1,3 +1,7 @@
+.group-project-team-wrapper {
+    margin-top: 20px;
+}
+
 .group-project-team-wrapper .group-project-team-email-group {
     text-align: right;
     display: block;

--- a/group_project_v2/public/css/group_project.css
+++ b/group_project_v2/public/css/group_project.css
@@ -155,8 +155,8 @@
 }
 
 .group-project-xblock-wrapper .xblock-reveal.reveal-modal.open {
-    min-width: 500px;
-    position: fixed;
+    min-width: 600px;
+    position: absolute;
     top: 20%;
     left: 0;
     right:0;

--- a/group_project_v2/public/css/group_project.css
+++ b/group_project_v2/public/css/group_project.css
@@ -180,10 +180,6 @@
     color: #E37222;
 }
 
-.message .message_text {
-    font-size: 16px;
-}
-
 .message .message_text .icon {
     color: #3384ca;
 }

--- a/group_project_v2/public/css/group_project.css
+++ b/group_project_v2/public/css/group_project.css
@@ -242,7 +242,6 @@
 }
 
 .group-project-xblock-wrapper .block-link {
-    color: #e37222;
     font-weight: bold;
 }
 

--- a/group_project_v2/public/css/project_navigator/project_navigator.css
+++ b/group_project_v2/public/css/project_navigator/project_navigator.css
@@ -34,6 +34,7 @@
     margin: 0;
     padding: 12px 10px;
     background-color: #f3f3f3;
+    text-align: center;
 }
 
 .group-project-navigator-view-selector li {

--- a/group_project_v2/public/css/project_navigator/project_navigator.css
+++ b/group_project_v2/public/css/project_navigator/project_navigator.css
@@ -82,7 +82,7 @@
 }
 
 .group-project-navigator-view .group-project-navigator-view-close {
-    color: #e5ebee;
+    color: #AAAAAA;
     font-size: 16px;
     float: right;
     cursor: pointer;

--- a/group_project_v2/public/css/project_navigator/submissions_view.css
+++ b/group_project_v2/public/css/project_navigator/submissions_view.css
@@ -19,7 +19,6 @@
 
 .group-project-submissions-view .uploader .file-progress-box {
     background-color: transparent;
-    width: 83%;
     height: 5px;
     visibility: hidden;
 }

--- a/group_project_v2/public/css/project_navigator/submissions_view.css
+++ b/group_project_v2/public/css/project_navigator/submissions_view.css
@@ -44,7 +44,7 @@
 
 .group-project-submissions-view .uploader .uploader-upload-controls-wrapper {
     min-width: 180px;
-    padding-right: 32px; /* placing label in wrapper padding: 30px lable width + 2px "margin" */
+    padding-right: 35px; /* placing label in wrapper padding: 30px label width + 5px "margin" */
 }
 
 .group-project-submissions-view .uploader .upload_item_wrapper {
@@ -56,7 +56,7 @@
 
 .group-project-submissions-view .uploader label {
     width: 30px;
-    margin-right: -32px;
+    margin-right: -35px;  /* to stick it to right border, this should be the same as uploader-upload-controls-wrapper right padding */
     display: inline-block;
     text-align: right;
     vertical-align: top;

--- a/group_project_v2/public/js/components/project_team.js
+++ b/group_project_v2/public/js/components/project_team.js
@@ -5,9 +5,12 @@ function ProjectTeamXBlock(runtime, element) {
     var group_project_dom = $(element).parents(".group-project-xblock-wrapper");
     var message_box = $(".message", group_project_dom);
 
-    function show_message(msg, title) {
+    function show_message(msg, title, title_css_class) {
         message_box.find('.message_text').html(msg);
         message_box.find('.message_title').html(title);
+        if (title_css_class) {
+            message_box.find('.message_title').addClass(title_css_class);
+        }
         message_box.show();
     }
 
@@ -40,6 +43,8 @@ function ProjectTeamXBlock(runtime, element) {
             data: data
         }).done(function (data) {
             show_message(data.message, 'Notification');
+        }).fail(function (data) {
+            show_message(data.message, 'Error', 'error');
         });
     });
 

--- a/group_project_v2/public/js/components/submission.js
+++ b/group_project_v2/public/js/components/submission.js
@@ -23,7 +23,7 @@ function GroupProjectSubmissionBlock(runtime, element) {
         message_box.find('.message_text').html(msg);
         message_box.find('.message_title').html(title);
         if (title_css_class) {
-            message_box.find('.message_title').addClass(title_css_class)
+            message_box.find('.message_title').addClass(title_css_class);
         }
         message_box.show();
     }

--- a/group_project_v2/templates/html/components/project_team.html
+++ b/group_project_v2/templates/html/components/project_team.html
@@ -8,9 +8,6 @@
       </div>
       <div class="group-project-team-member-data">
         <div class="group-project-team-member-info">
-          <div class="group-project-team-member-username">
-            {{ team_member.user_label }}
-          </div>
           <div class="group-project-team-member-name">{{ team_member.full_name }}</div>
           <div class="group-project-team-member-title">
             {% if team_member.title %}{{ team_member.title }}{% endif %}

--- a/group_project_v2/templates/html/components/submission_navigator_view.html
+++ b/group_project_v2/templates/html/components/submission_navigator_view.html
@@ -14,15 +14,15 @@
           value="{{ upload.file_name }}" data-original-value="{{ upload.file_name }}"
         {% endif %}
       />
+      <div class="{{ submission.upload_id }}_progress_box file-progress-box">
+        <div class="{{ submission.upload_id }}_progress file-progress"></div>
+      </div>
     </div>
     <input style="display:none;" class="file_upload" name="{{ submission.upload_id }}" id="{{ submission.upload_id }}" type="file" {% if disabled %} disabled="disabled"{% endif %}/>
   </div>
   {% if submission.description %}
     <div class="description">{{ submission.description }}</div>
   {% endif %}
-  <div class="{{ submission.upload_id }}_progress_box file-progress-box">
-    <div class="{{ submission.upload_id }}_progress file-progress"></div>
-  </div>
   {% if upload.location %}
     <div class="upload_item_data">
       {% trans "Uploaded by" %} {{ upload.user_details.user_label }} on {{ upload.submission_date }}


### PR DESCRIPTION
Fixes:

* Popups positioned absolutely (instead of fixed) - should respect parent width and overall look fine. The issue that caused to change this is that long discussion threads span below bottom border of *viewport* and was impossible to view. Now they should just stretch the viewport.
* Centered view selector buttons
* 5px margin between upload button and input
* Fixed upload progress - should be the same as upload input
* Darker close button for nav views - should be `#aaa`
* Project team XBlock have 20px top margin
* Emails to teammember/group - should now hit the proper endpoint in Apros (was broken) and display success/failure messages. Local Apros installs are not configured to send emails, so it will always show an error. There're no indication of success/error though, so if it hit the endpoint and got response it will display "Notification"-style message (with green title).
* Project team used to display teammember names twice (one for username + link, one actual name). Profile links was replaced with just full names, and it resulted in doubling full name. Removed the one supposed to be a link.
* Links to PN views in static help texts made normal links (with blue color and hover)