### PR TITLE
Feedback review stages completion conditions

### DIFF
--- a/group_project_v2/mixins.py
+++ b/group_project_v2/mixins.py
@@ -113,6 +113,10 @@ class WorkgroupAwareXBlockMixin(UserAwareXBlockMixin, CourseAwareXBlockMixin):
     FALLBACK_WORKGROUP = {"id": "0", "users": []}
 
     @property
+    def group_id(self):
+        return self.workgroup['id']
+
+    @property
     def is_group_member(self):
         return self.user_id in [u["id"] for u in self.workgroup["users"]]
 

--- a/tests/unit/test_group_project.py
+++ b/tests/unit/test_group_project.py
@@ -7,7 +7,7 @@ from xblock.runtime import Runtime
 
 from group_project_v2.stage_components import GroupProjectReviewQuestionXBlock
 from xblock.field_data import DictFieldData
-from tests.utils import TestWithPatchesMixin
+from tests.utils import TestWithPatchesMixin, make_review_item
 
 
 def _make_question(question_id):
@@ -18,7 +18,7 @@ def _make_question(question_id):
 
 def _make_reviews(reviews):
     return [
-        {'reviewer': reviewer, 'question': question, 'answer': answer}
+        make_review_item(reviewer, question, answer=answer)
         for reviewer, question, answer in reviews
     ]
 

--- a/tests/unit/test_project_api.py
+++ b/tests/unit/test_project_api.py
@@ -4,11 +4,7 @@ import ddt
 import mock
 from group_project_v2.json_requests import GET
 from group_project_v2.project_api import ProjectAPI, WORKGROUP_API
-from tests.utils import TestWithPatchesMixin
-
-
-def _make_review_item(reviewer, peer, question, content_id=None):
-    return {'reviewer': reviewer, 'user': peer, 'question': question, 'content_id': content_id}
+from tests.utils import TestWithPatchesMixin, make_review_item as mri
 
 
 @ddt.ddt
@@ -183,14 +179,14 @@ class TestProjectApi(TestCase, TestWithPatchesMixin):
             patched_get_stage_completions.assert_called_once_with(course_id, content_id, stage)
 
     @ddt.data(
-        (1, 2, [_make_review_item(1, 2, 'qwe'), _make_review_item(1, 3, 'asd')], [_make_review_item(1, 2, 'qwe')]),
+        (1, 2, [mri(1, 'qwe', peer=2), mri(1, 'asd', peer=3)], [mri(1, 'qwe', peer=2)]),
         (
             5, 3,
-            [_make_review_item(5, 3, 'qwe'), _make_review_item(5, 3, 'asd')],
-            [_make_review_item(5, 3, 'qwe'), _make_review_item(5, 3, 'asd')]
+            [mri(5, 'qwe', peer=3), mri(5, 'asd', peer=3)],
+            [mri(5, 'qwe', peer=3), mri(5, 'asd', peer=3)]
         ),
-        (11, 12, [_make_review_item(11, 3, 'qwe'), _make_review_item(11, 4, 'asd')], []),
-        (11, 12, [_make_review_item(15, 12, 'qwe'), _make_review_item(18, 12, 'asd')], []),
+        (11, 12, [mri(11, 'qwe', peer=3), mri(11, 'asd', peer=4)], []),
+        (11, 12, [mri(15, 'qwe', peer=12), mri(18, 'asd', peer=12)], []),
     )
     @ddt.unpack
     def test_get_peer_review_items(self, reviewer_id, peer_id, review_items, expected_result):
@@ -202,21 +198,10 @@ class TestProjectApi(TestCase, TestWithPatchesMixin):
             patched_get_review_items.assert_called_once_with('group_id', 'content_id')
 
     @ddt.data(
-        (
-            1,
-            [_make_review_item(2, 1, 'qwe'), _make_review_item(5, 1, 'asd')],
-            [_make_review_item(2, 1, 'qwe'), _make_review_item(5, 1, 'asd')]),
-        (
-            5,
-            [_make_review_item(7, 5, 'qwe'), _make_review_item(7, 5, 'asd')],
-            [_make_review_item(7, 5, 'qwe'), _make_review_item(7, 5, 'asd')]
-        ),
-        (11, [_make_review_item(16, 3, 'qwe'), _make_review_item(18, 4, 'asd')], []),
-        (
-            11,
-            [_make_review_item(16, 3, 'qwe'), _make_review_item(18, 11, 'question1')],
-            [_make_review_item(18, 11, 'question1')]
-        ),
+        (1, [mri(2, 'qwe', peer=1), mri(5, 'asd', peer=1)], [mri(2, 'qwe', peer=1), mri(5, 'asd', peer=1)]),
+        (5, [mri(7, 'qwe', peer=5), mri(7, 'asd', peer=5)], [mri(7, 'qwe', peer=5), mri(7, 'asd', peer=5)]),
+        (11, [mri(16, 'qwe', peer=3), mri(18, 'asd', peer=4)], []),
+        (11, [mri(16, 'qwe', peer=3), mri(18, 'question1', peer=11)], [mri(18, 'question1', peer=11)]),
     )
     @ddt.unpack
     def test_get_user_peer_review_items(self, user_id, review_items, expected_result):
@@ -227,24 +212,25 @@ class TestProjectApi(TestCase, TestWithPatchesMixin):
             self.assertEqual(result, expected_result)
             patched_get_review_items.assert_called_once_with('group_id', 'content_id')
 
+    # pylint: disable=too-many-function-args
     @ddt.data(
         (
             1, 'content_1',
-            [_make_review_item(1, 7, 'qwe', 'content_1'), _make_review_item(1, 7, 'asd', 'content_1')],
-            [_make_review_item(1, 7, 'qwe', 'content_1'), _make_review_item(1, 7, 'asd', 'content_1')]),
+            [mri(1, 'qwe', peer=7, content_id='content_1'), mri(1, 'asd', peer=7, content_id='content_1')],
+            [mri(1, 'qwe', peer=7, content_id='content_1'), mri(1, 'asd', peer=7, content_id='content_1')]),
         (
             5, 'content_2',
-            [_make_review_item(5, 14, 'qwe', 'content_2'), _make_review_item(5, 19, 'asd', 'content_2')],
-            [_make_review_item(5, 14, 'qwe', 'content_2'), _make_review_item(5, 19, 'asd', 'content_2')]
+            [mri(5, 'qwe', peer=14, content_id='content_2'), mri(5, 'asd', peer=19, content_id='content_2')],
+            [mri(5, 'qwe', peer=14, content_id='content_2'), mri(5, 'asd', peer=19, content_id='content_2')]
         ),
         (
             11, 'content_3',
-            [_make_review_item(11, 3, 'qwe', 'content_2'), _make_review_item(16, 4, 'asd', 'content_3')], []
+            [mri(11, 'qwe', peer=3, content_id='content_2'), mri(16, 'asd', peer=4, content_id='content_3')], []
         ),
         (
             11, 'content_4',
-            [_make_review_item(12, 18, 'qwe', 'content_4'), _make_review_item(11, 18, 'question1', 'content_4')],
-            [_make_review_item(11, 18, 'question1', 'content_4')]
+            [mri(12, 'qwe', peer=18, content_id='content_4'), mri(11, 'question1', peer=18, content_id='content_4')],
+            [mri(11, 'question1', peer=18, content_id='content_4')]
         ),
     )
     @ddt.unpack

--- a/tests/unit/test_stages.py
+++ b/tests/unit/test_stages.py
@@ -1,0 +1,191 @@
+from unittest import TestCase
+import ddt
+import mock
+from xblock.field_data import DictFieldData
+from group_project_v2.group_project import GroupActivityXBlock
+from group_project_v2.project_api import ProjectAPI, UserDetails
+from group_project_v2.stage import EvaluationDisplayStage, GradeDisplayStage
+from tests.utils import TestWithPatchesMixin, make_review_item
+
+
+class BaseStageTest(TestCase, TestWithPatchesMixin):
+    block_to_test = None
+    user_id = 1
+    workgroup_data = {
+        "id": 1,
+        "users": [
+            {"id": 1}, {"id": 2}, {"id": 3}
+        ]
+    }
+
+    def setUp(self):
+        self.runtime_mock = mock.Mock()
+        self.activity_mock = mock.create_autospec(GroupActivityXBlock)
+        self.activity_mock.content_id = '123456'
+        # can't use create_autospec here, as most methods are wrapped in decorators and mock fails signature checks
+        # with "Too many positional arguments" because of this
+        self.project_api_mock = mock.Mock(spec_set=ProjectAPI)
+
+        # pylint: disable=not-callable
+        self.block = self.block_to_test(self.runtime_mock, field_data=DictFieldData({}), scope_ids=mock.Mock())
+        self.make_patch(self.block_to_test, 'project_api', mock.PropertyMock(return_value=self.project_api_mock))
+        self.make_patch(self.block_to_test, 'activity', mock.PropertyMock(return_value=self.activity_mock))
+        self.real_user_id_mock = self.make_patch(self.block, 'real_user_id', mock.Mock(side_effect=lambda u_id: u_id))
+        self.workgroup_mock = self.make_patch(
+            self.block_to_test, 'workgroup', mock.PropertyMock(return_value=self.workgroup_data)
+        )
+        self.user_id_mock = self.make_patch(
+            self.block_to_test, 'user_id', mock.PropertyMock(return_value=self.user_id)
+        )
+
+
+@ddt.ddt
+class EvaluationStagesBaseTestMixin(object):
+    def setUp(self):
+        super(EvaluationStagesBaseTestMixin, self).setUp()
+
+    @ddt.data(
+        (False, False, False),
+        (True, False, False),
+        (False, True, False),
+        (True, True, True),
+    )
+    @ddt.unpack
+    def test_can_mark_complete_base_conditions(self, available_now, is_group_member, should_call_get_reviews):
+        self.available_now_mock.return_value = available_now
+        self.is_group_member_mock.return_value = is_group_member
+        with mock.patch.object(self.block, 'get_reviews') as patched_get_reviews, \
+                mock.patch.object(self.block, 'get_reviewer_ids') as patched_get_reviewer_ids:
+            result = self.block.can_mark_complete
+
+            if should_call_get_reviews:
+                patched_get_reviews.assert_called_once_with()
+                patched_get_reviewer_ids.assert_called_once_with()
+            else:
+                self.assertFalse(patched_get_reviews.called)
+                self.assertFalse(patched_get_reviewer_ids.called)
+
+            if not available_now or not is_group_member:
+                self.assertFalse(result)
+
+    # pylint: disable=invalid-name
+    def test_can_mark_complete_no_questions_returns_false(self):
+        with mock.patch.object(self.block_to_test, 'required_questions') as patched_required_questions:
+            patched_required_questions.return_value = []
+
+            self.assertFalse(self.block.can_mark_complete)
+
+    @ddt.data(
+        (False, False),
+        (True, True)
+    )
+    @ddt.unpack
+    def test_marks_complete_on_student_view(self, can_mark_complete, should_call_mark_complete):
+        can_mark_mock = mock.PropertyMock(return_value=can_mark_complete)
+        with mock.patch.object(self.block_to_test, 'can_mark_complete', can_mark_mock):
+            self.block.student_view({})
+
+            if should_call_mark_complete:
+                self.project_api_mock.mark_as_complete.assert_called_with(
+                    self.block.course_id, self.block.content_id, self.block.user_id, self.block.id
+                )
+            else:
+                self.assertFalse(self.project_api_mock.mark_as_complete.called)
+
+
+@ddt.ddt
+class TestEvaluationDisplayStage(BaseStageTest, EvaluationStagesBaseTestMixin):
+    block_to_test = EvaluationDisplayStage
+
+    def setUp(self):
+        super(TestEvaluationDisplayStage, self).setUp()
+
+        self.available_now_mock = self.make_patch(
+            self.block_to_test, 'available_now', mock.PropertyMock(return_value=False)
+        )
+        self.is_group_member_mock = self.make_patch(
+            self.block_to_test, 'is_group_member', mock.PropertyMock(return_value=False)
+        )
+
+        self.team_members_mock = self.make_patch(
+            self.block_to_test, 'team_members', mock.PropertyMock(return_value=[])
+        )
+
+    # pylint: disable=invalid-name
+    def test_can_mark_complete_no_reviewers_returns_false(self):
+        self.team_members_mock.return_value = []
+
+        self.assertFalse(self.block.can_mark_complete)
+
+    @ddt.data(
+        ([10], ["q1"], [], False),
+        ([10], ["q1"], [make_review_item(10, "q1")], True),
+        ([10], ["q1"], [make_review_item(10, "q1"), make_review_item(10, "q2")], True),
+        ([10], ["q1"], [make_review_item(11, "q1")], False),
+        ([10], ["q1"], [make_review_item(10, "q2"), make_review_item(11, "q1")], False),
+        ([10, 11], ["q1"], [make_review_item(10, "q1"), make_review_item(11, "q1")], True),
+        ([10, 11], ["q1", "q2"], [make_review_item(10, "q1"), make_review_item(11, "q1")], False),
+    )
+    @ddt.unpack
+    def test_can_mark_compete_suite(self, reviewers, questions, reviews, expected_result):
+        self.available_now_mock.return_value = True
+        self.is_group_member_mock.return_value = True
+
+        self.team_members_mock.return_value = [UserDetails(id=user_id) for user_id in reviewers]
+        self.project_api_mock.get_user_peer_review_items.return_value = reviews
+
+        with mock.patch.object(
+            self.block_to_test, 'required_questions', mock.PropertyMock()
+        ) as patched_required_questions:
+            patched_required_questions.return_value = questions
+
+            self.assertEqual(self.block.can_mark_complete, expected_result)
+
+
+@ddt.ddt
+class TestGradeDisplayStage(BaseStageTest, EvaluationStagesBaseTestMixin):
+    block_to_test = GradeDisplayStage
+
+    def setUp(self):
+        super(TestGradeDisplayStage, self).setUp()
+
+        self.available_now_mock = self.make_patch(
+            self.block_to_test, 'available_now', mock.PropertyMock(return_value=False)
+        )
+        self.is_group_member_mock = self.make_patch(
+            self.block_to_test, 'is_group_member', mock.PropertyMock(return_value=False)
+        )
+        self.project_api_mock.get_workgroup_reviewers.return_value = [{"id": 1}]
+
+    # pylint: disable=invalid-name
+    def test_can_mark_complete_no_reviewers_returns_false(self):
+        self.project_api_mock.get_workgroup_reviewers.return_value = []
+
+        self.assertFalse(self.block.can_mark_complete)
+
+    @ddt.data(
+        ([10], ["q1"], [], False),
+        ([10], ["q1"], [make_review_item(10, "q1")], True),
+        ([10], ["q1"], [make_review_item(10, "q1"), make_review_item(10, "q2")], True),
+        ([10], ["q1"], [make_review_item(11, "q1")], False),
+        ([10], ["q1"], [make_review_item(10, "q2"), make_review_item(11, "q1")], False),
+        ([10, 11], ["q1"], [make_review_item(10, "q1"), make_review_item(11, "q1")], True),
+        ([10, 11], ["q1", "q2"], [make_review_item(10, "q1"), make_review_item(11, "q1")], False),
+    )
+    @ddt.unpack
+    def test_can_mark_compete_suite(self, reviewers, questions, reviews, expected_result):
+        self.available_now_mock.return_value = True
+        self.is_group_member_mock.return_value = True
+
+        self.project_api_mock.get_workgroup_reviewers.return_value = [{'id': user_id} for user_id in reviewers]
+        self.project_api_mock.get_workgroup_review_items_for_group.return_value = reviews
+
+        with mock.patch.object(
+            self.block_to_test, 'required_questions', mock.PropertyMock()
+        ) as patched_required_questions:
+            patched_required_questions.return_value = questions
+
+            self.assertEqual(self.block.can_mark_complete, expected_result)
+            self.project_api_mock.get_workgroup_review_items_for_group.assert_called_once_with(
+                self.block.group_id, self.block.content_id
+            )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -87,3 +87,9 @@ def make_api_error(code, reason):
 
 def raise_api_error(code, reason):
     raise make_api_error(code, reason)
+
+
+def make_review_item(reviewer, question, peer=None, content_id=None, answer=None):
+    return {
+        'reviewer': reviewer, 'user': peer, 'question': question, 'content_id': content_id, 'answer': answer
+    }


### PR DESCRIPTION
Changes in this PR: Team Evaluation Display and Grade Display stages now marked as complete if all the feedback display components ("Team Evaluation Display" and "Grade Evaluation Display) that are configured to show feedback on **required** questions have feedback from all users assigned review:

* For Team Evaluation - all other team members
* For Grade Evaluation - all users that got the group assigned for review.

Testing instructions:

* Add Team Evaluation and Peer Grading stages (+ assign reviews for PG stage in Apros). Mark at least some questions as required.
* Add Team Evaluation Display and Grade Display stages.
* Do not perform any reviews yet.
* Go to Team Eval Display and Grade Display - note they are not marked as complete
* Perform *some* reviews, go to TED stage and GD stage - note they are not marked as complete
* Perform *all* required reviews, go to TED and GD - note they are now marked as complete.