### PR TITLE
Completion events via runtime.publish

### DIFF
--- a/group_project_v2/group_project.py
+++ b/group_project_v2/group_project.py
@@ -393,12 +393,7 @@ class GroupActivityXBlock(
         return fragment
 
     def mark_complete(self, user_id):
-        try:
-            self.project_api.mark_as_complete(self.course_id, self.content_id, user_id)
-        except ApiError as e:
-            # 409 indicates that the completion record already existed. That's ok in this case
-            if e.code != 409:
-                raise
+        self.runtime.publish(self, 'progress', {'user_id': user_id})
 
     def validate_field_data(self, validation, data):
         super(GroupActivityXBlock, self).validate_field_data(validation, data)

--- a/group_project_v2/group_project.py
+++ b/group_project_v2/group_project.py
@@ -28,7 +28,6 @@ from group_project_v2.stage import (
     EvaluationDisplayStage, GradeDisplayStage, CompletionStage,
     STAGE_TYPES
 )
-from group_project_v2.api_error import ApiError
 
 
 log = logging.getLogger(__name__)

--- a/group_project_v2/project_api.py
+++ b/group_project_v2/project_api.py
@@ -213,15 +213,6 @@ class ProjectAPI(object):
         return self.send_request(POST, (COURSES_API, course_id, 'completions'), data=completion_data)
 
     @api_error_protect
-    def get_stage_completions(self, course_id, content_id, stage_id):
-        qs_params = {
-            "content_id": content_id,
-            "stage": stage_id
-        }
-        response = self.send_request(GET, (COURSES_API, course_id, 'completions'), query_params=qs_params)
-        return response.get('results', [])
-
-    @api_error_protect
     def get_user_roles_for_course(self, user_id, course_id):
         qs_params = {
             "user_id": user_id,
@@ -255,15 +246,6 @@ class ProjectAPI(object):
             reviewers.extend(review_assignment_details["users"])
 
         return reviewers
-
-    def get_stage_state(self, course_id, content_id, stage):
-        stage_completions = self.get_stage_completions(course_id, content_id, stage)
-        if stage_completions:
-            completed_users = {completion['user_id'] for completion in stage_completions}
-        else:
-            completed_users = set()
-
-        return completed_users
 
     def get_peer_review_items(self, reviewer_id, peer_id, group_id, content_id):
         teammate_evaluation_items = self.get_peer_review_items_for_group(group_id, content_id)

--- a/tests/integration/test_project_navigator.py
+++ b/tests/integration/test_project_navigator.py
@@ -2,7 +2,6 @@
 Tests for project navigator and its views
 """
 import logging
-import mock
 
 from group_project_v2.project_navigator import ViewTypes
 from group_project_v2.stage import (
@@ -91,19 +90,7 @@ class TestProjectNavigatorViews(SingleScenarioTestSuite):
         Tests navigation view and stage navigation
         """
         # arrange: setting up mocks influencing stage states
-        def stage_states(course_id, activity_id, stage_id):  # pylint: disable=unused-argument
-            completed_users = {1, 2}
-            if BasicStage.CATEGORY in stage_id:
-                completed_users = {1, 2}  # overview is completed
-            elif CompletionStage.CATEGORY in stage_id:
-                completed_users = {}  # completion is not started
-            elif EvaluationDisplayStage.CATEGORY in stage_id:
-                completed_users = {1, 3, 4}  # evaluation display is complete
-            elif GradeDisplayStage.CATEGORY in stage_id:
-                completed_users = {1, 3, 4}  # grade display is complete
-            return completed_users
 
-        self.project_api_mock.get_stage_state = mock.Mock(side_effect=stage_states)
         self.project_api_mock.get_latest_workgroup_submissions_by_id.return_value = self.submissions
 
         self._prepare_page()
@@ -122,13 +109,13 @@ class TestProjectNavigatorViews(SingleScenarioTestSuite):
             self.assertEqual(stage.state, stage_state)
 
         stages = nav_view.stages
-        assert_stage(stages[0], "Activity 1", BasicStage, "Overview", StageState.COMPLETED)
-        assert_stage(stages[1], "Activity 1", SubmissionStage, "Upload", StageState.INCOMPLETE)
+        assert_stage(stages[0], "Activity 1", BasicStage, "Overview", StageState.COMPLETED)  # marks self as complete
+        assert_stage(stages[1], "Activity 1", SubmissionStage, "Upload", StageState.INCOMPLETE)  # one submission
         assert_stage(stages[2], "Activity 1", CompletionStage, "Completion", StageState.NOT_STARTED)
         assert_stage(stages[3], "Activity 2", TeamEvaluationStage, "Review Team", StageState.NOT_STARTED)
-        assert_stage(stages[4], "Activity 2", PeerReviewStage, "Review Group", StageState.COMPLETED)
-        assert_stage(stages[5], "Activity 2", EvaluationDisplayStage, "Evaluate Team Feedback", StageState.COMPLETED)
-        assert_stage(stages[6], "Activity 2", GradeDisplayStage, "Evaluate Group Feedback", StageState.COMPLETED)
+        assert_stage(stages[4], "Activity 2", PeerReviewStage, "Review Group", StageState.COMPLETED)  # no reviews
+        assert_stage(stages[5], "Activity 2", EvaluationDisplayStage, "Evaluate Team Feedback", StageState.NOT_STARTED)
+        assert_stage(stages[6], "Activity 2", GradeDisplayStage, "Evaluate Group Feedback", StageState.NOT_STARTED)
 
         # need to get this now as `navigate_to` will navigate from the page and `stage` instance will become detached
         stage_ids = [stage.stage_id for stage in nav_view.stages]

--- a/tests/unit/test_project_api.py
+++ b/tests/unit/test_project_api.py
@@ -157,28 +157,6 @@ class TestProjectApi(TestCase, TestWithPatchesMixin):
             self.assertEqual(response, [1, 2, 3] * len(expected_urls))
 
     @ddt.data(
-        ('course-1', 'content-1', 'stage-1', None),
-        ('course-1', 'content-1', 'stage-1', []),
-        ('course-2', 'content-2', 'stage-2', [1, 2, 3]),
-        ('other_course', 'no_content', 'missing_stage', [120, 514, 997]),
-    )
-    @ddt.unpack
-    def test_get_stage_state(self, course_id, content_id, stage, completed_users):
-        if completed_users:
-            completions = [{'user_id': user_id} for user_id in completed_users]
-            expected_result = set(completed_users)
-        else:
-            completions = None
-            expected_result = set()
-
-        with mock.patch.object(self.project_api, 'get_stage_completions') as patched_get_stage_completions:
-            patched_get_stage_completions.return_value = completions
-            result = self.project_api.get_stage_state(course_id, content_id, stage)
-
-            self.assertEqual(result, expected_result)
-            patched_get_stage_completions.assert_called_once_with(course_id, content_id, stage)
-
-    @ddt.data(
         (1, 2, [mri(1, 'qwe', peer=2), mri(1, 'asd', peer=3)], [mri(1, 'qwe', peer=2)]),
         (
             5, 3,

--- a/tests/unit/test_stages.py
+++ b/tests/unit/test_stages.py
@@ -79,9 +79,7 @@ class EvaluationStagesBaseTestMixin(object):
             self.block.student_view({})
 
             if should_call_mark_complete:
-                self.project_api_mock.mark_as_complete.assert_called_with(
-                    self.block.course_id, self.block.content_id, self.block.user_id, self.block.id
-                )
+                self.runtime_mock.publish.assert_called_with(self.block, 'progress', {'user_id': self.block.user_id})
             else:
                 self.assertFalse(self.project_api_mock.mark_as_complete.called)
 


### PR DESCRIPTION
Switched xblocks to use normal progress events instead of API calls to create completion data