### PR TITLE
Dedicated notifications type

### DIFF
--- a/group_project_v2/notifications.py
+++ b/group_project_v2/notifications.py
@@ -23,7 +23,7 @@ def add_click_link_params(msg, course_id, location):
     In the initial use case, we need to make the link point to a different front end website so we need to
     resolve these links at dispatch time
     """
-    msg.add_click_link_params({'course_id': unicode(course_id), 'activity_location': unicode(location)})
+    msg.add_click_link_params({'course_id': unicode(course_id), 'location': unicode(location)})
 
 
 class StageNotificationsMixin(object):
@@ -82,7 +82,7 @@ class StageNotificationsMixin(object):
             if self.open_date:
                 self._set_activity_timed_notification(
                     course_id,
-                    u'open-edx.xblock.group-project.stage-open',
+                    u'open-edx.xblock.group-project-v2.stage-open',
                     datetime.combine(self.open_date, datetime.min.time()),
                     datetime.combine(self.open_date, datetime.min.time()),
                     services,
@@ -92,7 +92,7 @@ class StageNotificationsMixin(object):
             if self.close_date:
                 self._set_activity_timed_notification(
                     course_id,
-                    u'open-edx.xblock.group-project.stage-due',
+                    u'open-edx.xblock.group-project-v2.stage-due',
                     datetime.combine(self.close_date, datetime.min.time()),
                     datetime.combine(self.close_date, datetime.min.time()),
                     services,
@@ -102,7 +102,7 @@ class StageNotificationsMixin(object):
                 # send a notice 3 days prior to closing stage
                 self._set_activity_timed_notification(
                     course_id,
-                    u'open-edx.xblock.group-project.stage-due',
+                    u'open-edx.xblock.group-project-v2.stage-due',
                     datetime.combine(self.close_date, datetime.min.time()),
                     datetime.combine(self.close_date, datetime.min.time()) - timedelta(days=3),
                     services,
@@ -133,7 +133,7 @@ class ActivityNotificationsMixin(object):
     @log_and_suppress_exceptions
     def fire_file_upload_notification(self, notifications_service):
         # this NotificationType is registered in the list of default Open edX Notifications
-        msg_type = notifications_service.get_notification_type('open-edx.xblock.group-project.file-uploaded')
+        msg_type = notifications_service.get_notification_type('open-edx.xblock.group-project-v2.file-uploaded')
 
         workgroup_user_ids = []
         uploader_username = ''
@@ -164,7 +164,7 @@ class ActivityNotificationsMixin(object):
     @log_and_suppress_exceptions
     def fire_grades_posted_notification(self, group_id, notifications_service):
         # this NotificationType is registered in the list of default Open edX Notifications
-        msg_type = notifications_service.get_notification_type('open-edx.xblock.group-project.grades-posted')
+        msg_type = notifications_service.get_notification_type('open-edx.xblock.group-project-v2.grades-posted')
         msg = NotificationMessage(
             msg_type=msg_type,
             namespace=unicode(self.course_id),

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,7 @@ mock
 ddt
 freezegun
 
--e git+https://github.com/edx-solutions/xblock-sdk.git@6b140be40ea3a9129ddc6fb6815c95f29a90d6d3#egg=xblock_sdk
+-e git+https://github.com/edx/xblock-sdk.git@ffdaa80b9857c4d6b6cb7307c742bd187ef40aed#egg=xblock_sdk
 -e git+https://github.com/edx/opaque-keys.git@1254ed4d615a428591850656f39f26509b86d30a#egg=opaque-keys
 -e git://github.com/nosedjango/nosedjango.git@ed7d7f9aa969252ff799ec159f828eaa8c1cbc5a#egg=nosedjango-dev
 -e git+https://github.com/edx/edx-notifications.git@8038452f6fbb2b95ad46f8fe7a2f80b145b45b9c#egg=edx-notifications

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,6 +2,7 @@ mock
 ddt
 freezegun
 
--e git+https://github.com/edx-solutions/xblock-sdk.git@70fe6fcea496ede27c640b5b0657c94d4feecd1c#egg=xblock_sdk
+-e git+https://github.com/edx-solutions/xblock-sdk.git@6b140be40ea3a9129ddc6fb6815c95f29a90d6d3#egg=xblock_sdk
 -e git+https://github.com/edx/opaque-keys.git@1254ed4d615a428591850656f39f26509b86d30a#egg=opaque-keys
 -e git://github.com/nosedjango/nosedjango.git@ed7d7f9aa969252ff799ec159f828eaa8c1cbc5a#egg=nosedjango-dev
+-e git+https://github.com/edx/edx-notifications.git@8038452f6fbb2b95ad46f8fe7a2f80b145b45b9c#egg=edx-notifications

--- a/tests/unit/test_notifications.py
+++ b/tests/unit/test_notifications.py
@@ -37,7 +37,8 @@ class TestActivityNotificationsMixin(TestCase, TestWithPatchesMixin):
     workgroup1 = make_workgroup([1, 2, 3])
     workgroup2 = make_workgroup([7, 12, 54])
 
-    def _raise(self, exception):
+    @staticmethod
+    def _raise(exception):
         raise exception
 
     def setUp(self):
@@ -46,10 +47,10 @@ class TestActivityNotificationsMixin(TestCase, TestWithPatchesMixin):
         self.notifications_service_mock.bulk_publish_notification_to_users = mock.Mock()
         self.notifications_service_mock.bulk_publish_notification_to_scope = mock.Mock()
 
-    def _get_call_args(self, target):
+    def _get_call_args(self, target):  # pylint: disable=invalid-name
         self.assertTrue(target.called)
         self.assertEqual(len(target.call_args_list), 1)
-        args, _ = target.call_args
+        args, _kwargs = target.call_args
         return args
 
     @ddt.data(
@@ -58,7 +59,8 @@ class TestActivityNotificationsMixin(TestCase, TestWithPatchesMixin):
         (54, 'course3', 'yet-another-location', workgroup2, 'NotAnActivity'),
     )
     @ddt.unpack
-    def test_fire_file_upload_notification_success_scenario(self, user_id, course_id, location, workgroup, name):
+    # pylint: disable=invalid-name
+    def test_file_upload_success_scenario(self, user_id, course_id, location, workgroup, name):
         block = ActivityNotificationsGuineaPig(user_id, course_id, location, workgroup, name)
 
         expected_user = next(user for user in workgroup['users'] if user['id'] == user_id)
@@ -84,7 +86,8 @@ class TestActivityNotificationsMixin(TestCase, TestWithPatchesMixin):
             )
 
     @ddt.data(ValueError("test"), TypeError("QWE"), AttributeError("OMG"), Exception("Very Generic"))
-    def test_file_upload_get_notification_type_raises(self, exception):
+    # pylint: disable=invalid-name
+    def test_file_upload_notification_type_raises(self, exception):
         block = ActivityNotificationsGuineaPig('irrelevant', 'irrelevant', 'irrelevant', 'irrelevant', 'irrelevant')
         with mock.patch('logging.Logger.exception') as patched_exception_logger:
             self.notifications_service_mock.get_notification_type.side_effect = lambda msg_type: self._raise(exception)
@@ -108,7 +111,7 @@ class TestActivityNotificationsMixin(TestCase, TestWithPatchesMixin):
         (17, 'course3', 'yet-another-location', 'NotAnActivity'),
     )
     @ddt.unpack
-    def test_fire_grades_posted_notification_success_scenario(self, group_id, course_id, location, name):
+    def test_grades_posted_success_scenario(self, group_id, course_id, location, name):
         block = ActivityNotificationsGuineaPig('irrelevant', course_id, location, 'irrelevant', name)
 
         with mock.patch('edx_notifications.data.NotificationMessage.add_click_link_params') as patched_link_params:
@@ -134,7 +137,8 @@ class TestActivityNotificationsMixin(TestCase, TestWithPatchesMixin):
             )
 
     @ddt.data(ValueError("test"), TypeError("QWE"), AttributeError("OMG"), Exception("Very Generic"))
-    def test_grades_posted__notification_raises(self, exception):
+    # pylint: disable=invalid-name
+    def test_grades_posted_notification_type_raises(self, exception):
         block = ActivityNotificationsGuineaPig('irrelevant', 'irrelevant', 'irrelevant', 'irrelevant', 'irrelevant')
         with mock.patch('logging.Logger.exception') as patched_exception_logger:
             self.notifications_service_mock.get_notification_type.side_effect = lambda msg_type: self._raise(exception)

--- a/tests/unit/test_notifications.py
+++ b/tests/unit/test_notifications.py
@@ -1,0 +1,153 @@
+from unittest import TestCase
+import ddt
+import mock
+from group_project_v2.notifications import ActivityNotificationsMixin, NotificationMessageTypes, NotificationScopes
+from tests.utils import TestWithPatchesMixin
+from edx_notifications.data import NotificationType
+
+
+def get_notification_type(message_type):
+    return NotificationType(
+        name=message_type,
+        renderer='',
+        renderer_context={}
+    )
+
+
+def make_workgroup(user_ids):
+    return {
+        "users": [
+            {"id": user_id, "username": "User"+str(user_id), "email": "{0}@example.com".format(user_id)}
+            for user_id in user_ids
+        ]
+    }
+
+
+class ActivityNotificationsGuineaPig(ActivityNotificationsMixin):
+    def __init__(self, user_id, course_id, location, workgroup, display_name):
+        self.user_id = user_id
+        self.course_id = course_id
+        self.location = location
+        self.workgroup = workgroup
+        self.display_name = display_name
+
+
+@ddt.ddt
+class TestActivityNotificationsMixin(TestCase, TestWithPatchesMixin):
+    workgroup1 = make_workgroup([1, 2, 3])
+    workgroup2 = make_workgroup([7, 12, 54])
+
+    def _raise(self, exception):
+        raise exception
+
+    def setUp(self):
+        self.notifications_service_mock = mock.Mock()
+        self.notifications_service_mock.get_notification_type = mock.Mock(side_effect=get_notification_type)
+        self.notifications_service_mock.bulk_publish_notification_to_users = mock.Mock()
+        self.notifications_service_mock.bulk_publish_notification_to_scope = mock.Mock()
+
+    def _get_call_args(self, target):
+        self.assertTrue(target.called)
+        self.assertEqual(len(target.call_args_list), 1)
+        args, _ = target.call_args
+        return args
+
+    @ddt.data(
+        (1, 'course1', 'some-location', workgroup1, 'Activity1'),
+        (2, 'course2', 'other-location', workgroup1, 'Activity2'),
+        (54, 'course3', 'yet-another-location', workgroup2, 'NotAnActivity'),
+    )
+    @ddt.unpack
+    def test_fire_file_upload_notification_success_scenario(self, user_id, course_id, location, workgroup, name):
+        block = ActivityNotificationsGuineaPig(user_id, course_id, location, workgroup, name)
+
+        expected_user = next(user for user in workgroup['users'] if user['id'] == user_id)
+        expected_action_username = expected_user['username']
+        expected_user_ids = set([user['id'] for user in workgroup['users']]) - {user_id}
+
+        with mock.patch('edx_notifications.data.NotificationMessage.add_click_link_params') as patched_link_params:
+            block.fire_file_upload_notification(self.notifications_service_mock)
+
+            self.notifications_service_mock.get_notification_type.assert_called_once_with(
+                NotificationMessageTypes.FILE_UPLOADED
+            )
+
+            user_ids, message = self._get_call_args(self.notifications_service_mock.bulk_publish_notification_to_users)
+            self.assertEqual(set(user_ids), expected_user_ids)
+            self.assertEqual(message.msg_type.name, NotificationMessageTypes.FILE_UPLOADED)
+            self.assertEqual(message.namespace, unicode(course_id))
+            self.assertEqual(message.payload['action_username'], expected_action_username)
+            self.assertEqual(message.payload['activity_name'], name)
+
+            patched_link_params.assert_called_once_with(
+                {'course_id': unicode(course_id), 'location': unicode(location)}
+            )
+
+    @ddt.data(ValueError("test"), TypeError("QWE"), AttributeError("OMG"), Exception("Very Generic"))
+    def test_file_upload_get_notification_type_raises(self, exception):
+        block = ActivityNotificationsGuineaPig('irrelevant', 'irrelevant', 'irrelevant', 'irrelevant', 'irrelevant')
+        with mock.patch('logging.Logger.exception') as patched_exception_logger:
+            self.notifications_service_mock.get_notification_type.side_effect = lambda msg_type: self._raise(exception)
+
+            block.fire_file_upload_notification(self.notifications_service_mock)
+            patched_exception_logger.assert_called_once_with(exception)
+
+    @ddt.data(ValueError("test"), TypeError("QWE"), AttributeError("OMG"), Exception("Very Generic"))
+    def test_file_upload_publish_raises(self, exception):
+        block = ActivityNotificationsGuineaPig(1, 'irrelevant', 'irrelevant', self.workgroup1, 'irrelevant')
+        with mock.patch('logging.Logger.exception') as patched_exception_logger:
+            self.notifications_service_mock.bulk_publish_notification_to_users.side_effect = \
+                lambda unused_1, unused_2: self._raise(exception)
+
+            block.fire_file_upload_notification(self.notifications_service_mock)
+            patched_exception_logger.assert_called_once_with(exception)
+
+    @ddt.data(
+        (1, 'course1', 'some-location', 'Activity1'),
+        (2, 'course2', 'other-location', 'Activity2'),
+        (17, 'course3', 'yet-another-location', 'NotAnActivity'),
+    )
+    @ddt.unpack
+    def test_fire_grades_posted_notification_success_scenario(self, group_id, course_id, location, name):
+        block = ActivityNotificationsGuineaPig('irrelevant', course_id, location, 'irrelevant', name)
+
+        with mock.patch('edx_notifications.data.NotificationMessage.add_click_link_params') as patched_link_params:
+            block.fire_grades_posted_notification(group_id, self.notifications_service_mock)
+
+            self.notifications_service_mock.get_notification_type.assert_called_once_with(
+                NotificationMessageTypes.GRADES_POSTED
+            )
+
+            scope, scope_args, message = self._get_call_args(
+                self.notifications_service_mock.bulk_publish_notification_to_scope
+            )
+
+            self.assertEqual(scope, NotificationScopes.WORKGROUP)
+            self.assertEqual(scope_args, {'workgroup_id': group_id})
+
+            self.assertEqual(message.msg_type.name, NotificationMessageTypes.GRADES_POSTED)
+            self.assertEqual(message.namespace, unicode(course_id))
+            self.assertEqual(message.payload['activity_name'], name)
+
+            patched_link_params.assert_called_once_with(
+                {'course_id': unicode(course_id), 'location': unicode(location)}
+            )
+
+    @ddt.data(ValueError("test"), TypeError("QWE"), AttributeError("OMG"), Exception("Very Generic"))
+    def test_grades_posted__notification_raises(self, exception):
+        block = ActivityNotificationsGuineaPig('irrelevant', 'irrelevant', 'irrelevant', 'irrelevant', 'irrelevant')
+        with mock.patch('logging.Logger.exception') as patched_exception_logger:
+            self.notifications_service_mock.get_notification_type.side_effect = lambda msg_type: self._raise(exception)
+
+            block.fire_grades_posted_notification('irrelevant', self.notifications_service_mock)
+            patched_exception_logger.assert_called_once_with(exception)
+
+    @ddt.data(ValueError("test"), TypeError("QWE"), AttributeError("OMG"), Exception("Very Generic"))
+    def test_grades_posted_publish_raises(self, exception):
+        block = ActivityNotificationsGuineaPig(1, 'irrelevant', 'irrelevant', self.workgroup1, 'irrelevant')
+        with mock.patch('logging.Logger.exception') as patched_exception_logger:
+            self.notifications_service_mock.bulk_publish_notification_to_scope.side_effect = \
+                lambda unused_1, unused_2, unused_3: self._raise(exception)
+
+            block.fire_grades_posted_notification('irrelevant', self.notifications_service_mock)
+            patched_exception_logger.assert_called_once_with(exception)


### PR DESCRIPTION
**Background:** Group Project XBlock sends notifications for file upload, grades posted and stage open/close dates. Group Project v2 sends the same types of messages, but uses different navigation approach, so the URLs in messages need to be different. For this to work, GP v2 has to send messages of unique types. 

**Description:** This PR switches GP v2 to use dedicated message types

**Dependencies:** This PR is one of the three that fix notifications in Group Project v2 XBlock; the other two are:
* https://github.com/edx-solutions/edx-platform/pull/517 - adds URLResolvers
* https://github.com/edx/edx-notifications/pull/162 - registers new message types

**Related:** [YONK-146](https://openedx.atlassian.net/browse/YONK-146) was caused by changing URL resolvers for GP v1. Should not be affected by this change.

**Testing instructions:** see testing instructions on https://github.com/edx-solutions/edx-platform/pull/517