### PR TITLE
Switch to using xblock-utils nested xblock helpers

### DIFF
--- a/group_project_v2/group_project.py
+++ b/group_project_v2/group_project.py
@@ -10,11 +10,12 @@ from xblock.fields import Scope, String, Float, Integer, DateTime
 from xblock.fragment import Fragment
 from xblock.validation import ValidationMessage
 
-from xblockutils.studio_editable import StudioEditableXBlockMixin, StudioContainerXBlockMixin
+from xblockutils.studio_editable import (
+    StudioEditableXBlockMixin, StudioContainerXBlockMixin, XBlockWithPreviewMixin, NestedXBlockSpec
+)
 
 from group_project_v2.mixins import (
-    ChildrenNavigationXBlockMixin, WorkgroupAwareXBlockMixin, XBlockWithComponentsMixin, XBlockWithPreviewMixin,
-    NestedXBlockSpec
+    ChildrenNavigationXBlockMixin, WorkgroupAwareXBlockMixin, XBlockWithComponentsMixin
 )
 from group_project_v2.notifications import ActivityNotificationsMixin
 from group_project_v2.project_navigator import GroupProjectNavigatorXBlock

--- a/group_project_v2/group_project.py
+++ b/group_project_v2/group_project.py
@@ -20,7 +20,7 @@ from group_project_v2.mixins import (
 from group_project_v2.notifications import ActivityNotificationsMixin
 from group_project_v2.project_navigator import GroupProjectNavigatorXBlock
 from group_project_v2.utils import (
-    loader, mean, make_key, outsider_disallowed_protected_view, get_default_stage, DiscussionXBlockProxy, Constants,
+    loader, mean, make_key, outsider_disallowed_protected_view, get_default_stage, DiscussionXBlockShim, Constants,
     add_resource, gettext as _
 )
 from group_project_v2.stage import (
@@ -73,7 +73,7 @@ class GroupProjectXBlock(
         return [
             NestedXBlockSpec(GroupActivityXBlock),
             NestedXBlockSpec(GroupProjectNavigatorXBlock, single_instance=True),
-            NestedXBlockSpec(DiscussionXBlockProxy, single_instance=True)
+            NestedXBlockSpec(DiscussionXBlockShim, single_instance=True)
         ]
 
     @lazy
@@ -168,7 +168,7 @@ class GroupProjectXBlock(
             child_context
         )
 
-        discussion = self.get_child_of_category(DiscussionXBlockProxy.CATEGORY)
+        discussion = self.get_child_of_category(DiscussionXBlockShim.CATEGORY)
         render_child_fragment(
             discussion, 'discussion_content',
             _(u"This Group Project V2 does not contain a discussion"),

--- a/group_project_v2/project_navigator.py
+++ b/group_project_v2/project_navigator.py
@@ -17,7 +17,7 @@ from group_project_v2.mixins import (
     XBlockWithUrlNameDisplayMixin, AdminAccessControlXBlockMixin, NoStudioEditableSettingsMixin,
 )
 
-from group_project_v2.utils import loader, gettext as _, DiscussionXBlockProxy, add_resource
+from group_project_v2.utils import loader, gettext as _, DiscussionXBlockShim, add_resource
 
 log = logging.getLogger(__name__)
 
@@ -432,7 +432,7 @@ class PrivateDiscussionViewXBlock(ProjectNavigatorViewXBlockBase):
     initialize_js_function = "GroupProjectPrivateDiscussionView"
 
     def _project_has_discussion(self):
-        return self.navigator.group_project.has_child_of_category(DiscussionXBlockProxy.CATEGORY)
+        return self.navigator.group_project.has_child_of_category(DiscussionXBlockShim.CATEGORY)
 
     @property
     def is_view_available(self):

--- a/group_project_v2/project_navigator.py
+++ b/group_project_v2/project_navigator.py
@@ -9,11 +9,12 @@ from xblock.exceptions import NoSuchUsage
 from xblock.fragment import Fragment
 from xblock.validation import ValidationMessage
 
-from xblockutils.studio_editable import StudioContainerXBlockMixin, StudioEditableXBlockMixin
+from xblockutils.studio_editable import (
+    StudioContainerXBlockMixin, StudioEditableXBlockMixin, XBlockWithPreviewMixin, NestedXBlockSpec
+)
 from group_project_v2.mixins import (
-    XBlockWithComponentsMixin, XBlockWithPreviewMixin, ChildrenNavigationXBlockMixin,
+    XBlockWithComponentsMixin, ChildrenNavigationXBlockMixin,
     XBlockWithUrlNameDisplayMixin, AdminAccessControlXBlockMixin, NoStudioEditableSettingsMixin,
-    NestedXBlockSpec
 )
 
 from group_project_v2.utils import loader, gettext as _, DiscussionXBlockProxy, add_resource

--- a/group_project_v2/stage.py
+++ b/group_project_v2/stage.py
@@ -26,7 +26,7 @@ from group_project_v2.stage_components import (
     GroupProjectTeamEvaluationDisplayXBlock, GroupProjectGradeEvaluationDisplayXBlock,
 )
 from group_project_v2.utils import (
-    loader, format_date, gettext as _, make_key, get_link_to_block, HtmlXBlockProxy, Constants, MUST_BE_OVERRIDDEN,
+    loader, format_date, gettext as _, make_key, get_link_to_block, HtmlXBlockShim, Constants, MUST_BE_OVERRIDDEN,
     outsider_disallowed_protected_view, outsider_disallowed_protected_handler, key_error_protected_handler,
     conversion_protected_handler,
     add_resource)
@@ -127,7 +127,7 @@ class BaseGroupActivityStage(
         """
         This property outputs an ordered dictionary of allowed nested XBlocks in form of block_category: block_caption.
         """
-        blocks = [HtmlXBlockProxy, GroupProjectResourceXBlock]
+        blocks = [HtmlXBlockShim, GroupProjectResourceXBlock]
         if GroupProjectVideoResourceXBlock.is_available():
             blocks.append(GroupProjectVideoResourceXBlock)
         blocks.append(ProjectTeamXBlock)

--- a/group_project_v2/stage.py
+++ b/group_project_v2/stage.py
@@ -10,12 +10,12 @@ from xblock.core import XBlock
 from xblock.fields import Scope, String, DateTime, Boolean
 from xblock.fragment import Fragment
 from xblock.validation import ValidationMessage
-from xblockutils.studio_editable import StudioEditableXBlockMixin, StudioContainerXBlockMixin
+from xblockutils.studio_editable import StudioEditableXBlockMixin, StudioContainerXBlockMixin, XBlockWithPreviewMixin
 
 from group_project_v2.api_error import ApiError
 from group_project_v2.mixins import (
     ChildrenNavigationXBlockMixin,
-    WorkgroupAwareXBlockMixin, XBlockWithComponentsMixin, XBlockWithPreviewMixin,
+    WorkgroupAwareXBlockMixin, XBlockWithComponentsMixin,
     XBlockWithUrlNameDisplayMixin, AdminAccessControlXBlockMixin
 )
 from group_project_v2.notifications import StageNotificationsMixin

--- a/group_project_v2/stage_components.py
+++ b/group_project_v2/stage_components.py
@@ -11,10 +11,10 @@ from xblock.core import XBlock
 from xblock.fields import String, Boolean, Scope, UNIQUE_ID
 from xblock.fragment import Fragment
 from xblock.validation import ValidationMessage
-from xblockutils.studio_editable import StudioEditableXBlockMixin
+from xblockutils.studio_editable import StudioEditableXBlockMixin, XBlockWithPreviewMixin
 
 from group_project_v2.api_error import ApiError
-from group_project_v2.mixins import WorkgroupAwareXBlockMixin, XBlockWithPreviewMixin, NoStudioEditableSettingsMixin
+from group_project_v2.mixins import WorkgroupAwareXBlockMixin, NoStudioEditableSettingsMixin
 from group_project_v2.project_api import ProjectAPIXBlockMixin
 from group_project_v2.project_navigator import ResourcesViewXBlock, SubmissionsViewXBlock
 from group_project_v2.upload_file import UploadFile

--- a/group_project_v2/utils.py
+++ b/group_project_v2/utils.py
@@ -36,12 +36,12 @@ class Constants(object):
     CURRENT_STAGE_ID_PARAMETER_NAME = 'current_stage'
 
 
-class HtmlXBlockProxy(object):
+class HtmlXBlockShim(object):
     CATEGORY = 'html'
     STUDIO_LABEL = gettext(u"HTML")
 
 
-class DiscussionXBlockProxy(object):
+class DiscussionXBlockShim(object):
     CATEGORY = "discussion-forum"
     STUDIO_LABEL = gettext(u"Discussion")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/edx/xblock-utils.git@25f15734ec8d29fde0e114bbd199fd48638865ae#egg=xblock-utils
+-e git+https://github.com/edx/xblock-utils.git@08e5a5a9fc8ab46b627435427fd7e04c20809009#egg=xblock-utils
 -e .
 lxml>=3.0.1
 lazy>=1.1


### PR DESCRIPTION
**Description:** Switches GP to use utils versions of nested XBlock support stuff

**Testing instructions:**
This changeset only affects studio editing - make sure add/edit/reorder/delete nested XBlocks works as expected (including keeping single child of Project Navigator and Discussion XBlock)