### PR TITLE
Show error message instead of throwing 500 for misconfigured review step.

### DIFF
--- a/group_project_v2/stage_components.py
+++ b/group_project_v2/stage_components.py
@@ -615,7 +615,10 @@ class GroupProjectBaseFeedbackDisplayXBlock(
     @outsider_disallowed_protected_view
     def student_view(self, context):
         if self.question is None:
-            raise ValueError(self.NO_QUESTION_SELECTED)
+            return Fragment(
+                u'This component is misconfigured and can\'t be displayed.  '
+                u'It needs to be fixed by the course authors.'
+            )
 
         raw_feedback = self.get_feedback()
 


### PR DESCRIPTION
For testing, remove one of the questions the grade feedback blocks in a review step are referring to and publish the unit.  You should be seeing the error message below instead of the affected grade, and the reset of the page (including the project navigator and the other grades) should render normally.