### PR TITLE
Fixes from QA - batch 5

### DIFF
--- a/group_project_v2/api_error.py
+++ b/group_project_v2/api_error.py
@@ -2,7 +2,7 @@ import logging
 import json
 from urllib2 import HTTPError
 
-from django.utils.translation import ugettext as _
+from group_project_v2.utils import gettext as _
 
 
 log = logging.getLogger(__name__)

--- a/group_project_v2/group_project.py
+++ b/group_project_v2/group_project.py
@@ -177,7 +177,7 @@ class GroupProjectXBlock(
         fragment.add_content(loader.render_template("templates/html/group_project.html", render_context))
 
         add_resource(self, 'css', 'public/css/group_project.css', fragment)
-        add_resource(self, 'css', 'public/css/vendor/font-awesome/font-awesome.css', fragment)
+        add_resource(self, 'css', 'public/css/vendor/font-awesome/font-awesome.css', fragment, via_url=True)
         add_resource(self, 'javascript', 'public/js/group_project.js', fragment)
         fragment.initialize_js("GroupProjectBlock")
         return fragment

--- a/group_project_v2/group_project.py
+++ b/group_project_v2/group_project.py
@@ -4,8 +4,6 @@ import itertools
 from lazy.lazy import lazy
 from opaque_keys import InvalidKeyError
 
-from django.utils.translation import ugettext as _
-
 from xblock.core import XBlock
 from xblock.exceptions import NoSuchUsage
 from xblock.fields import Scope, String, Float, Integer, DateTime
@@ -22,7 +20,8 @@ from group_project_v2.notifications import ActivityNotificationsMixin
 from group_project_v2.project_navigator import GroupProjectNavigatorXBlock
 from group_project_v2.utils import (
     loader, mean, make_key, outsider_disallowed_protected_view, get_default_stage, DiscussionXBlockProxy, Constants,
-    add_resource)
+    add_resource, gettext as _
+)
 from group_project_v2.stage import (
     BasicStage, SubmissionStage, TeamEvaluationStage, PeerReviewStage,
     EvaluationDisplayStage, GradeDisplayStage, CompletionStage,

--- a/group_project_v2/project_api.py
+++ b/group_project_v2/project_api.py
@@ -123,7 +123,9 @@ class ProjectAPI(object):
         self.send_request(DELETE, (PEER_REVIEW_API, assessment_id))
 
     @api_error_protect
-    @memoize_with_expiration(expires_after=DEFAULT_EXPIRATION_TIME)
+    # Do not cache - used both in submitting review and calculating grade, so if this call is cached grade calculation
+    # sees old value. So, when last review is performed, grade calculation does not see it and returns "No grade yet".
+    # See MCKIN-3501 and MCKIN-3471 for what would happen than.
     def get_workgroup_review_items_for_group(self, group_id, content_id):
         qs_params = {"content_id": content_id}
         return self.send_request(GET, (WORKGROUP_API, group_id, 'workgroup_reviews'), query_params=qs_params)

--- a/group_project_v2/project_api.py
+++ b/group_project_v2/project_api.py
@@ -203,18 +203,6 @@ class ProjectAPI(object):
         return self.send_request(GET, (GROUP_API, group_id))
 
     @api_error_protect
-    def mark_as_complete(self, course_id, content_id, user_id, stage_id=None):
-        completion_data = {
-            "content_id": content_id,
-            "user_id": user_id,
-        }
-
-        if stage_id is not None:
-            completion_data["stage"] = str(stage_id)
-
-        return self.send_request(POST, (COURSES_API, course_id, 'completions'), data=completion_data)
-
-    @api_error_protect
     def get_user_roles_for_course(self, user_id, course_id):
         qs_params = {
             "user_id": user_id,

--- a/group_project_v2/project_navigator.py
+++ b/group_project_v2/project_navigator.py
@@ -396,7 +396,7 @@ class AskTAViewXBlock(ProjectNavigatorViewXBlockBase):
     selector_text = u"TA"
     display_name_with_default = STUDIO_LABEL
 
-    SORT_ORDER = 3
+    SORT_ORDER = 4
 
     template = "ask_ta_view.html"
     css_file = "ask_ta_view.css"
@@ -425,7 +425,7 @@ class PrivateDiscussionViewXBlock(ProjectNavigatorViewXBlockBase):
     skip_content = True  # there're no content in this view so far - it only shows discussion in a popup
     display_name_with_default = STUDIO_LABEL
 
-    SORT_ORDER = 4
+    SORT_ORDER = 3
 
     js_file = "private_discussion_view.js"
     initialize_js_function = "GroupProjectPrivateDiscussionView"

--- a/group_project_v2/public/js/components/project_team.js
+++ b/group_project_v2/public/js/components/project_team.js
@@ -1,6 +1,6 @@
 function ProjectTeamXBlock(runtime, element) {
-    const email_member_modal_selector = ".group-project-team-email-member-modal";
-    const email_group_modal_selector = ".group-project-team-email-group-modal";
+    var email_member_modal_selector = ".group-project-team-email-member-modal";
+    var email_group_modal_selector = ".group-project-team-email-group-modal";
 
     var group_project_dom = $(element).parents(".group-project-xblock-wrapper");
     var message_box = $(".message", group_project_dom);

--- a/group_project_v2/public/js/group_project.js
+++ b/group_project_v2/public/js/group_project.js
@@ -1,7 +1,7 @@
 function GroupProjectBlock(runtime, element) {
-    const activate_project_nav_view_event = 'group_project_v2.project_navigator.activate_view';
-    const show_group_project_discussion = 'group_project_v2.discussion.show';
-    const hide_group_project_discussion = 'group_project_v2.discussion.hide';
+    var activate_project_nav_view_event = 'group_project_v2.project_navigator.activate_view';
+    var show_group_project_discussion = 'group_project_v2.discussion.show';
+    var hide_group_project_discussion = 'group_project_v2.discussion.hide';
 
     var message_box = $('.message', element);
     var discussion_box = $("#group-project-discussion", element);

--- a/group_project_v2/public/js/project_navigator/private_discussion_view.js
+++ b/group_project_v2/public/js/project_navigator/private_discussion_view.js
@@ -1,5 +1,5 @@
 function GroupProjectPrivateDiscussionView(runtime, element) {
-    const show_group_project_discussion = 'group_project_v2.discussion.show';
+    var show_group_project_discussion = 'group_project_v2.discussion.show';
 
     $(".view-selector-item", element).click(function(){
         $(document).trigger(show_group_project_discussion);

--- a/group_project_v2/public/js/project_navigator/project_navigator.js
+++ b/group_project_v2/public/js/project_navigator/project_navigator.js
@@ -1,8 +1,8 @@
 function GroupProjectNavigatorBlock(runtime, element, initialization_args) {
-    const initial_view = 'navigation';
-    const selector_item_query = ".group-project-navigator-view-selector .view-selector-item";
-    const activate_project_nav_view_event = 'group_project_v2.project_navigator.activate_view';
-    const hide_group_project_discussion = 'group_project_v2.discussion.hide';
+    var initial_view = 'navigation';
+    var selector_item_query = ".group-project-navigator-view-selector .view-selector-item";
+    var activate_project_nav_view_event = 'group_project_v2.project_navigator.activate_view';
+    var hide_group_project_discussion = 'group_project_v2.discussion.hide';
 
     var view_elements = $(".group-project-navigator-view", element),
         views = {},

--- a/group_project_v2/public/js/project_navigator/resources_view.js
+++ b/group_project_v2/public/js/project_navigator/resources_view.js
@@ -1,5 +1,5 @@
 function GroupProjectNavigatorResourcesView(runtime, element) {
-    const ooyala_player_target_element_id = 'group-project-resources-view-ooyala-player';
+    var ooyala_player_target_element_id = 'group-project-resources-view-ooyala-player';
 
     var modal = $('.player-modal', element),
         player = $('.player-wrapper', modal),

--- a/group_project_v2/public/js/project_navigator/submissions_view.js
+++ b/group_project_v2/public/js/project_navigator/submissions_view.js
@@ -1,7 +1,7 @@
 function GroupProjectNavigatorSubmissionsView(runtime, element) {
-    const upload_started_event = 'group_project_v2.submission.upload_started';
-    const upload_failed_event = 'group_project_v2.submission.upload_failed';
-    const upload_complete_event = 'group_project_v2.submission.upload_complete';
+    var upload_started_event = 'group_project_v2.submission.upload_started';
+    var upload_failed_event = 'group_project_v2.submission.upload_failed';
+    var upload_complete_event = 'group_project_v2.submission.upload_complete';
 
     var $action_buttons = $(".action_buttons", element);
 

--- a/group_project_v2/stage.py
+++ b/group_project_v2/stage.py
@@ -622,8 +622,19 @@ class TeamEvaluationStage(ReviewBaseStage):
         if self.grade_questions:
             violations.add(ValidationMessage(
                 ValidationMessage.ERROR,
-                _(u"Grade questions are not supported for {class_name} '{stage_title}'").format(
-                    class_name=self.__class__.__name__, stage_title=self.display_name
+                _(u"Grade questions are not supported for {class_name} stage '{stage_title}'").format(
+                    class_name=self.STUDIO_LABEL, stage_title=self.display_name
+                )
+            ))
+
+        if not self.has_child_of_category(PeerSelectorXBlock.CATEGORY):
+            violations.add(ValidationMessage(
+                ValidationMessage.ERROR,
+                _(
+                    u"{class_name} stage '{stage_title}' is missing required component '{peer_selector_class_name}'"
+                ).format(
+                    class_name=self.STUDIO_LABEL, stage_title=self.display_name,
+                    peer_selector_class_name=PeerSelectorXBlock.STUDIO_LABEL
                 )
             ))
 
@@ -707,6 +718,30 @@ class PeerReviewStage(ReviewBaseStage):
             )
 
         return self._check_review_status(groups_to_review, group_review_items, "workgroup")
+
+    def validate(self):
+        violations = super(PeerReviewStage, self).validate()
+
+        if not self.grade_questions:
+            violations.add(ValidationMessage(
+                ValidationMessage.ERROR,
+                _(u"Grade questions are required for {class_name} stage '{stage_title}'").format(
+                    class_name=self.STUDIO_LABEL, stage_title=self.display_name
+                )
+            ))
+
+        if not self.has_child_of_category(GroupSelectorXBlock.CATEGORY):
+            violations.add(ValidationMessage(
+                ValidationMessage.ERROR,
+                _(
+                    u"{class_name} stage '{stage_title}' is missing required component '{group_selector_class_name}'"
+                ).format(
+                    class_name=self.STUDIO_LABEL, stage_title=self.display_name,
+                    group_selector_class_name=GroupSelectorXBlock.STUDIO_LABEL
+                )
+            ))
+
+        return violations
 
     @XBlock.handler
     @outsider_disallowed_protected_handler

--- a/tests/integration/test_general.py
+++ b/tests/integration/test_general.py
@@ -1,33 +1,14 @@
 """
 High level rendering tests
 """
-from collections import defaultdict
 import logging
-import mock
 from tests.integration.base_test import SingleScenarioTestSuite
 
 log = logging.getLogger(__name__)
 
 
-class StageStateRegistry(object):
-    def __init__(self):
-        self._stage_states = defaultdict(list)
-
-    def mark_as_complete(self, course_id, content_id, user_id, stage_id):
-        self._stage_states[(course_id, content_id, stage_id)].append(user_id)
-
-    def get_stage_state(self, course_id, content_id, stage_id):
-        return self._stage_states[(course_id, content_id, stage_id)]
-
-
 class TestGeneralFunctionality(SingleScenarioTestSuite):
     scenario = "example_1.xml"
-
-    def setUp(self):
-        super(TestGeneralFunctionality, self).setUp()
-        stage_state_registry = StageStateRegistry()
-        self.project_api_mock.get_stage_state = mock.Mock(side_effect=stage_state_registry.get_stage_state)
-        self.project_api_mock.mark_as_complete = mock.Mock(side_effect=stage_state_registry.mark_as_complete)
 
     def test_initial_stage_visibility(self):
         self._prepare_page()

--- a/tests/integration/test_project_navigator.py
+++ b/tests/integration/test_project_navigator.py
@@ -218,18 +218,18 @@ class TestProjectNavigator(BaseIntegrationTest, TestWithPatchesMixin):
     @ddt.data(
         (
             # test case 1 - all orderable views, correct order
-            (SubmissionsViewXBlock, ResourcesViewXBlock,  AskTAViewXBlock, PrivateDiscussionViewXBlock),
-            (ViewTypes.SUBMISSIONS, ViewTypes.RESOURCES, ViewTypes.ASK_TA, ViewTypes.PRIVATE_DISCUSSION)
+            (SubmissionsViewXBlock, ResourcesViewXBlock, PrivateDiscussionViewXBlock, AskTAViewXBlock),
+            (ViewTypes.SUBMISSIONS, ViewTypes.RESOURCES, ViewTypes.PRIVATE_DISCUSSION, ViewTypes.ASK_TA)
         ),
         (
             # test case 2 - all orderable views, random order
             (AskTAViewXBlock, SubmissionsViewXBlock, PrivateDiscussionViewXBlock, ResourcesViewXBlock),
-            (ViewTypes.SUBMISSIONS, ViewTypes.RESOURCES, ViewTypes.ASK_TA, ViewTypes.PRIVATE_DISCUSSION)
+            (ViewTypes.SUBMISSIONS, ViewTypes.RESOURCES, ViewTypes.PRIVATE_DISCUSSION, ViewTypes.ASK_TA)
         ),
         (
             # test case 3 - some orderable views, correct order
-            (AskTAViewXBlock, PrivateDiscussionViewXBlock),
-            (ViewTypes.ASK_TA, ViewTypes.PRIVATE_DISCUSSION)
+            (PrivateDiscussionViewXBlock, AskTAViewXBlock),
+            (ViewTypes.PRIVATE_DISCUSSION, ViewTypes.ASK_TA)
         ),
         (
             # test case 4 - some orderable views, random order

--- a/tests/unit/test_stages.py
+++ b/tests/unit/test_stages.py
@@ -213,7 +213,7 @@ class EvaluationStagesBaseTestMixin(object):
             if should_call_mark_complete:
                 self.runtime_mock.publish.assert_called_with(self.block, 'progress', {'user_id': self.block.user_id})
             else:
-                self.assertFalse(self.project_api_mock.mark_as_complete.called)
+                self.assertFalse(self.runtime_mock.publish.called)
 
 
 @ddt.ddt

--- a/tests/unit/test_stages.py
+++ b/tests/unit/test_stages.py
@@ -2,9 +2,11 @@ from unittest import TestCase
 import ddt
 import mock
 from xblock.field_data import DictFieldData
+from xblock.validation import ValidationMessage
 from group_project_v2.group_project import GroupActivityXBlock
 from group_project_v2.project_api import ProjectAPI
-from group_project_v2.stage import EvaluationDisplayStage, GradeDisplayStage
+from group_project_v2.stage import EvaluationDisplayStage, GradeDisplayStage, TeamEvaluationStage, PeerReviewStage
+from group_project_v2.stage_components import PeerSelectorXBlock, GroupProjectReviewQuestionXBlock, GroupSelectorXBlock
 from tests.utils import TestWithPatchesMixin, make_review_item
 
 
@@ -37,6 +39,136 @@ class BaseStageTest(TestCase, TestWithPatchesMixin):
         self.user_id_mock = self.make_patch(
             self.block_to_test, 'user_id', mock.PropertyMock(return_value=self.user_id)
         )
+
+
+class ReviewStageChildrenMockContextManager(object):
+    def __init__(self, block, child_categories, questions):
+        self._block = block
+        self._child_categories = child_categories
+        self._questions = questions
+        self._patchers = []
+
+    def __enter__(self):
+        def _has_child_of_category(child_category):
+            return child_category in self._child_categories
+
+        has_child_mock = mock.Mock()
+        patch_has_child = mock.patch.object(self._block, 'has_child_of_category', has_child_mock)
+        has_child_mock.side_effect = _has_child_of_category
+        self._patchers.append(patch_has_child)
+
+        questions_mock = mock.PropertyMock()
+        questions_mock.return_value = self._questions
+        patch_questions = mock.patch.object(type(self._block), 'questions', questions_mock)
+        self._patchers.append(patch_questions)
+
+        for patch in self._patchers:
+            patch.start()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        for patch in self._patchers:
+            patch.stop()
+
+        return False
+
+
+class ReviewStageBaseTest(BaseStageTest):
+    def _make_question(self, required=False, graded=False):
+        fields = {
+            'grade': graded,
+            'required': required
+        }
+        return GroupProjectReviewQuestionXBlock(self.runtime_mock, DictFieldData(fields), scope_ids=mock.Mock())
+
+
+class TestTeamEvaluationStage(ReviewStageBaseTest):
+    block_to_test = TeamEvaluationStage
+
+    def setUp(self):
+        super(TestTeamEvaluationStage, self).setUp()
+
+    def test_validation_missing_peer_selector(self):
+        questions = [self._make_question()]
+        categories = []
+        with ReviewStageChildrenMockContextManager(self.block, categories, questions):
+            validation = self.block.validate()
+
+        messages = validation.messages
+        self.assertEqual(len(messages), 1)
+        message = messages[0]
+
+        self.assertEqual(message.type, ValidationMessage.ERROR)
+        self.assertIn(
+            u"missing required component '{ps_name}'".format(ps_name=PeerSelectorXBlock.STUDIO_LABEL),
+            message.text
+        )
+
+    def test_validation_has_graded_questions(self):
+        questions = [self._make_question(graded=True)]
+        categories = [GroupProjectReviewQuestionXBlock.CATEGORY, PeerSelectorXBlock.CATEGORY]
+        with ReviewStageChildrenMockContextManager(self.block, categories, questions):
+            validation = self.block.validate()
+
+        messages = validation.messages
+        self.assertEqual(len(messages), 1)
+        message = messages[0]
+
+        self.assertEqual(message.type, ValidationMessage.ERROR)
+        self.assertIn(u"Grade questions are not supported", message.text)
+
+    def test_validtion_passes(self):
+        questions = [self._make_question()]
+        categories = [GroupProjectReviewQuestionXBlock.CATEGORY, PeerSelectorXBlock.CATEGORY]
+        with ReviewStageChildrenMockContextManager(self.block, categories, questions):
+            validation = self.block.validate()
+
+        messages = validation.messages
+        self.assertEqual(len(messages), 0)
+
+
+class TestPeerReviewStage(ReviewStageBaseTest):
+    block_to_test = PeerReviewStage
+
+    def setUp(self):
+        super(TestPeerReviewStage, self).setUp()
+
+    def test_validation(self):
+        questions = [self._make_question(graded=True)]
+        categories = [GroupProjectReviewQuestionXBlock.CATEGORY]
+        with ReviewStageChildrenMockContextManager(self.block, categories, questions):
+            validation = self.block.validate()
+
+        messages = validation.messages
+        self.assertEqual(len(messages), 1)
+        message = messages[0]
+
+        self.assertEqual(message.type, ValidationMessage.ERROR)
+        self.assertIn(
+            u"missing required component '{gs_name}'".format(gs_name=GroupSelectorXBlock.STUDIO_LABEL),
+            message.text
+        )
+
+    def test_validation_no_graded_questions(self):
+        questions = [self._make_question(graded=False)]
+        categories = [GroupProjectReviewQuestionXBlock.CATEGORY, GroupSelectorXBlock.CATEGORY]
+        with ReviewStageChildrenMockContextManager(self.block, categories, questions):
+            validation = self.block.validate()
+
+        messages = validation.messages
+        self.assertEqual(len(messages), 1)
+        message = messages[0]
+
+        self.assertEqual(message.type, ValidationMessage.ERROR)
+        self.assertIn(u"Grade questions are required", message.text)
+
+    def test_validtion_passes(self):
+        questions = [self._make_question(graded=True)]
+        categories = [GroupProjectReviewQuestionXBlock.CATEGORY, GroupSelectorXBlock.CATEGORY]
+        with ReviewStageChildrenMockContextManager(self.block, categories, questions):
+            validation = self.block.validate()
+
+        messages = validation.messages
+        self.assertEqual(len(messages), 0)
 
 
 @ddt.ddt

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -67,7 +67,6 @@ def get_mock_project_api():
     mock_api.get_workgroup_reviewers = Mock(return_value={})
     mock_api.get_member_data = Mock(side_effect=_get_user_details)
 
-    mock_api.mark_as_complete = Mock(return_value={})
     return mock_api
 
 


### PR DESCRIPTION
* https://edx-wiki.atlassian.net/browse/MCKIN-3471 Proficiency score - When graded a group activity for gw v2, the proficiency score does not updated
* https://edx-wiki.atlassian.net/browse/MCKIN-3501 When group has been evaluated, members of that group doesn't received notification for posting grades
* https://edx-wiki.atlassian.net/browse/MCKIN-3502 Page is not loading for IE - 9,10
* https://edx-wiki.atlassian.net/browse/MCKIN-3473 UI - Change order of buttons on Project Navigator => Already fixed in https://github.com/open-craft/xblock-group-project-v2/commit/8ce0ce6d20dd0b82a09aa6463dfc4d6762bfd621 but with the wrong order

**Testing instructions:**
1. Score and grade notification - create a graded activity, set min rquired reviews to one (to simplify testing), add peer review stage + as many questions as you'd like. Create at least two groups (one student in each is enough) and generate review assignments via McKA admin. Log in as one student, go to course progress page (add `/progressv2` to course home page URL); mark all notifications as read (also make sure notifications are sent). Perform all the required reviews for the group that student is in (in  other browser or incognito window). *Expected result:* after last review, user receives notification "Grades available" immediately; proficiency score is updated on progress page when it is reloaded.
2. IE 9,10 - GP loads successfully (smoke test)
3. PN button order - correct order is: submissions, resources, private discussion, TA