### PR TITLE
Fixes from QA - batch 6

### DIFF
--- a/group_project_v2/group_project.py
+++ b/group_project_v2/group_project.py
@@ -449,11 +449,6 @@ class GroupActivityXBlock(CommonMixinCollection, XBlockWithPreviewMixin, Activit
             workgroup = self.project_api.get_workgroup_by_id(group_id)
             for u in workgroup["users"]:
                 self.mark_complete(u["id"])
-                self.runtime.publish(self, 'grade', {
-                    'user_id': u["id"],
-                    'value': grade_value,
-                    'max_value': self.weight,
-                })
 
     def assign_grade_to_group(self, group_id, grade_value):
         self.project_api.set_group_grade(
@@ -473,7 +468,6 @@ class GroupActivityXBlock(CommonMixinCollection, XBlockWithPreviewMixin, Activit
                 "content_id": self.content_id,
             }
         )
-
         notifications_service = self.runtime.service(self, 'notifications')
         if notifications_service:
             self.fire_grades_posted_notification(group_id, notifications_service)

--- a/group_project_v2/project_navigator.py
+++ b/group_project_v2/project_navigator.py
@@ -202,7 +202,7 @@ class ProjectNavigatorViewXBlockBase(
 
     @property
     def allow_admin_grader_access(self):
-        return False
+        return True
 
     @property
     def is_admin_grader(self):
@@ -297,10 +297,6 @@ class NavigationViewXBlock(ProjectNavigatorViewXBlockBase):
     js_file = "navigation_view.js"
     initialize_js_function = "GroupProjectNavigatorNavigationView"
 
-    @property
-    def allow_admin_grader_access(self):
-        return True
-
     def student_view(self, context):  # pylint: disable=unused-argument
         """
         Student view
@@ -370,6 +366,10 @@ class SubmissionsViewXBlock(ProjectNavigatorViewXBlockBase):
         'public/js/vendor/jquery.iframe-transport.js'
     )
 
+    @property
+    def allow_admin_grader_access(self):
+        return False
+
     def student_view(self, context):  # pylint: disable=unused-argument
         """
         Student view
@@ -401,6 +401,10 @@ class AskTAViewXBlock(ProjectNavigatorViewXBlockBase):
     css_file = "ask_ta_view.css"
     js_file = "ask_ta_view.js"
     initialize_js_function = "GroupProjectNavigatorAskTAView"
+
+    @property
+    def allow_admin_grader_access(self):
+        return False
 
     @classmethod
     def is_view_type_available(cls):

--- a/group_project_v2/project_navigator.py
+++ b/group_project_v2/project_navigator.py
@@ -174,7 +174,6 @@ class ProjectNavigatorViewXBlockBase(
     selector_text = None
     skip_selector = False
     skip_content = False
-    show_to_admin_grader = False
 
     TEMPLATE_BASE = "templates/html/project_navigator/"
     CSS_BASE = "public/css/project_navigator/"
@@ -290,7 +289,6 @@ class NavigationViewXBlock(ProjectNavigatorViewXBlockBase):
     icon = u"fa fa-bars"
     display_name_with_default = STUDIO_LABEL
     skip_selector = True
-    show_to_admin_grader = True
 
     SORT_ORDER = 0
 

--- a/group_project_v2/public/js/stages/review_stage.js
+++ b/group_project_v2/public/js/stages/review_stage.js
@@ -10,7 +10,8 @@ function GroupProjectReviewStage(runtime, element) {
     var SELECT_PEER_TO_REVIEW = gettext("Please select Teammate to review");
     var SELECT_GROUP_TO_REVIEW = gettext("Please select Group to review");
 
-    var $form = $("form.review",  element);
+    var $form = $(".review",  element);
+    var $submit_btn = $form.find('button.submit');
     var is_peer_review = $form.data('review-type') == 'peer_review';
     var group_project_dom = $(element).parents(".group-project-xblock-wrapper");
     var message_box = $(".message", group_project_dom);
@@ -129,11 +130,11 @@ function GroupProjectReviewStage(runtime, element) {
         return false;
     });
 
-    $form.on('submit', function (ev) {
+    $submit_btn.on('click', function (ev) {
         ev.preventDefault();
 
         $form.find(':submit').prop('disabled', true);
-        var items = $form.serializeArray();
+        var items = $form.find('input, select, textarea').serializeArray();
         var data = {};
         $.each(items, function (i, v) {
             data[v.name] = v.value;
@@ -147,8 +148,8 @@ function GroupProjectReviewStage(runtime, element) {
         }
 
         $.ajax({
-            type: $form.attr('method'),
-            url: runtime.handlerUrl(element, $form.attr('action')),
+            type: $form.data('method'),
+            url: runtime.handlerUrl(element, $form.data('action')),
             data: JSON.stringify(data),
             success: function (data) {
                 var msg = (data.msg) ? data.msg : gettext('Thanks for your feedback!');
@@ -204,7 +205,7 @@ function GroupProjectReviewStage(runtime, element) {
     if ($('.select_peer.selected,.select_group.selected', element).length === 0) {
         $form.find('.editable').attr('disabled', 'disabled');
         $form.find('.answer').val(null);
-        $form.find('button.submit').attr('disabled', 'disabled');
+        $submit_btn.attr('disabled', 'disabled');
     }
     $(element).ready(function () {
         var options = $('.select_peer,.select_group', element);

--- a/group_project_v2/stage_components.py
+++ b/group_project_v2/stage_components.py
@@ -216,7 +216,7 @@ class GroupProjectSubmissionXBlock(
     FAILED_UPLOAD_TITLE = _(u"Upload failed.")
     SUCCESSFUL_UPLOAD_MESSAGE_TPL = _(
         u"Your deliverable has been successfully uploaded. You can attach an updated version of the "
-        u"deliverable by clicking the <span class='icon {icon}'></span> icon at any time before the deadline passes."
+        u"deliverable by clicking the <span class='icon {icon}'></span> icon at any time before the deadline."
     )
     FAILED_UPLOAD_MESSAGE_TPL = _(u"Error uploading file: {error_goes_here}")
 

--- a/group_project_v2/stage_components.py
+++ b/group_project_v2/stage_components.py
@@ -442,7 +442,8 @@ class GroupProjectReviewQuestionXBlock(BaseStageComponentXBlock, StudioEditableX
     question_id = String(
         display_name=_(u"Question ID"),
         default=UNIQUE_ID,
-        scope=Scope.content
+        scope=Scope.content,
+        force_export=True
     )
 
     title = String(

--- a/group_project_v2/templates/html/stages/peer_review.html
+++ b/group_project_v2/templates/html/stages/peer_review.html
@@ -3,11 +3,11 @@
 <div class="grading_override ta_graded">{% trans "Grading View" %}</div>
 {% endif %}
 
-<form class="review other_group_review" data-review-type="group_review" action="submit_review" method="POST">
+<div class="review other_group_review" data-review-type="group_review" data-action="submit_review" data-method="POST">
   {% for child_content in children_contents %}{{ child_content|safe }}{% endfor %}
   <hr/>
   <button class="submit" {% if stage.is_closed %}disabled="disabled"{% endif %}>Submit</button>
-</form>
+</div>
 
 
 <div class="review_submissions_dialog">

--- a/group_project_v2/templates/html/stages/team_evaluation.html
+++ b/group_project_v2/templates/html/stages/team_evaluation.html
@@ -1,5 +1,5 @@
-<form class="review peer_review" data-review-type="peer_review" action="submit_review" method="POST">
+<div class="review peer_review" data-review-type="peer_review" data-action="submit_review" data-method="POST">
   {% for child_content in children_contents %}{{ child_content|safe }}{% endfor %}
   <hr/>
   <button class="submit" {% if stage.is_closed %}disabled="disabled"{% endif %}>Submit</button>
-</form>
+</div>

--- a/pylintrc
+++ b/pylintrc
@@ -10,7 +10,7 @@ symbols=yes
 disable=
  missing-docstring,no-member,
  fixme,
- locally-disabled,
+ locally-disabled,star-args,
  too-few-public-methods,too-many-public-methods,too-many-ancestors
 
 

--- a/tests/integration/page_elements.py
+++ b/tests/integration/page_elements.py
@@ -147,7 +147,7 @@ class ReviewStageElement(StageElement):
     """ Wrapper around group project review stage element """
     @property
     def form(self):
-        return self.make_element(self.element.find_element_by_tag_name('form'), ReviewFormElement)
+        return self.make_element(self.element.find_element_by_css_selector('div.review'), ReviewFormElement)
 
     @property
     def peers(self):

--- a/tests/integration/test_project_navigator.py
+++ b/tests/integration/test_project_navigator.py
@@ -122,7 +122,7 @@ class TestProjectNavigatorViews(SingleScenarioTestSuite, TestWithPatchesMixin):
         assert_stage(stages[1], "Activity 1", SubmissionStage, "Upload", StageState.INCOMPLETE)  # one submission
         assert_stage(stages[2], "Activity 1", CompletionStage, "Completion", StageState.NOT_STARTED)
         assert_stage(stages[3], "Activity 2", TeamEvaluationStage, "Review Team", StageState.NOT_STARTED)
-        assert_stage(stages[4], "Activity 2", PeerReviewStage, "Review Group", StageState.COMPLETED)  # no reviews
+        assert_stage(stages[4], "Activity 2", PeerReviewStage, "Review Group", StageState.NOT_STARTED)  # no reviews
         assert_stage(stages[5], "Activity 2", EvaluationDisplayStage, "Evaluate Team Feedback", StageState.NOT_STARTED)
         assert_stage(stages[6], "Activity 2", GradeDisplayStage, "Evaluate Group Feedback", StageState.NOT_STARTED)
 

--- a/tests/integration/test_project_navigator.py
+++ b/tests/integration/test_project_navigator.py
@@ -8,8 +8,8 @@ import ddt
 import mock
 
 from group_project_v2.project_navigator import (
-    ViewTypes, ResourcesViewXBlock, SubmissionsViewXBlock, AskTAViewXBlock, PrivateDiscussionViewXBlock
-)
+    ViewTypes, ResourcesViewXBlock, SubmissionsViewXBlock, AskTAViewXBlock, PrivateDiscussionViewXBlock,
+    NavigationViewXBlock)
 from group_project_v2.stage import (
     BasicStage, SubmissionStage, TeamEvaluationStage, PeerReviewStage,
     EvaluationDisplayStage, GradeDisplayStage, CompletionStage
@@ -18,7 +18,7 @@ from group_project_v2.stage.utils import StageState
 from tests.integration.base_test import SingleScenarioTestSuite, BaseIntegrationTest
 from tests.integration.page_elements import NavigationViewElement, ResourcesViewElement, SubmissionsViewElement, \
     GroupProjectElement
-from tests.utils import KNOWN_USERS, TestWithPatchesMixin
+from tests.utils import KNOWN_USERS, TestWithPatchesMixin, switch_to_ta_grading
 
 
 class TestProjectNavigatorViews(SingleScenarioTestSuite, TestWithPatchesMixin):
@@ -248,3 +248,27 @@ class TestProjectNavigator(BaseIntegrationTest, TestWithPatchesMixin):
 
         view_selector_types = tuple([view.type for view in project_navigator.view_selectors])
         self.assertEqual(view_selector_types, expected_views)
+
+    def test_ta_views_visibility(self):
+        views = (
+            NavigationViewXBlock, SubmissionsViewXBlock, ResourcesViewXBlock,
+            PrivateDiscussionViewXBlock, AskTAViewXBlock
+        )
+        switch_to_ta_grading(self.project_api_mock)
+        scenario_xml = self.build_scenario([view.CATEGORY for view in views])
+        self.load_scenario_xml(scenario_xml)
+        scenario = self.go_to_view()
+        page = GroupProjectElement(self.browser, scenario)
+        project_navigator = page.project_navigator
+
+        view_types = tuple([view.type for view in project_navigator.views])
+        view_selector_types = tuple([view.type for view in project_navigator.view_selectors])
+
+        self.assertEqual(
+            view_types,
+            (NavigationViewXBlock.type, ResourcesViewXBlock.type, PrivateDiscussionViewXBlock.type)
+        )
+        self.assertEqual(
+            view_selector_types,
+            (ResourcesViewXBlock.type, PrivateDiscussionViewXBlock.type)
+        )

--- a/tests/unit/test_group_project.py
+++ b/tests/unit/test_group_project.py
@@ -241,41 +241,6 @@ class TestEventsAndCompletionGroupActivityXBlock(TestWithPatchesMixin, TestCase)
                 group_id, course_id, content_id, grade, weight
             )
 
-    @ddt.data(
-        (1, 100, 'content1', []),
-        (2, 10, 'content2', [1, 2]),
-        (3, 92, 'contrent3', [10, 15, 112])
-    )
-    @ddt.unpack
-    def test_publishes_runtime_event(self, group_id, grade, content_id, workgroup_users):
-        self.calculate_grade_mock.return_value = grade
-        self.project_api_mock.get_workgroup_by_id.return_value = _make_workgroup(workgroup_users)
-
-        with mock.patch.object(GroupActivityXBlock, 'content_id', mock.PropertyMock(return_value=content_id)):
-            self.block.calculate_and_send_grade(group_id)
-
-            expected_calls = [
-                mock.call(
-                    self.block, "group_activity.final_grade",
-                    {
-                        "grade_value": grade,
-                        "group_id": group_id,
-                        "content_id": self.block.content_id,
-                    }
-                ),
-            ] + [
-                mock.call(
-                    self.block, 'grade', {
-                        'user_id': user,
-                        'value': grade,
-                        'max_value': self.block.weight,
-                    }
-                )
-                for user in workgroup_users
-            ]
-
-            self.assertEqual(self.runtime_mock.publish.call_args_list, expected_calls)
-
     @ddt.data(1, 2, 3)
     def test_sends_notifications_message(self, group_id):
         self.calculate_grade_mock.return_value = 100

--- a/tests/unit/test_stages.py
+++ b/tests/unit/test_stages.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 
 import ddt
+import itertools
 import mock
 from xblock.field_data import DictFieldData
 from xblock.validation import ValidationMessage
@@ -108,8 +109,11 @@ class ReviewStageBaseTest(object):
     @ddt.unpack
     def test_stage_state(self, review_stage_state, visited, expected_stage_state):
         self.block.visited = visited
-        with mock.patch.object(self.block_to_test, 'review_status') as patched_review_status:
+        patched_review_subjects = mock.PropertyMock()
+        with mock.patch.object(self.block_to_test, 'review_status') as patched_review_status, \
+                mock.patch.object(self.block_to_test, 'review_subjects', patched_review_subjects):
             patched_review_status.return_value = review_stage_state
+            patched_review_subjects.return_value = [{'id': 1}, {'id': 2}]
 
             self.assertEqual(self.block.get_stage_state(), expected_stage_state)
 
@@ -159,11 +163,29 @@ class TestTeamEvaluationStage(ReviewStageBaseTest, BaseStageTest):
         self.assertEqual(len(messages), 0)
 
 
+@ddt.ddt
 class TestPeerReviewStage(ReviewStageBaseTest, BaseStageTest):
     block_to_test = PeerReviewStage
 
     def setUp(self):
         super(TestPeerReviewStage, self).setUp()
+
+    @ddt.data(
+        *itertools.product(
+            (ReviewState.NOT_STARTED, ReviewState.INCOMPLETE, ReviewState.COMPLETED),
+            (True, False)
+        )
+    )
+    @ddt.unpack
+    def test_stage_state_no_reviews_assigned(self, review_stage_state, visited):
+        self.block.visited = visited
+        patched_review_subjects = mock.PropertyMock()
+        with mock.patch.object(self.block_to_test, 'review_status') as patched_review_status, \
+                mock.patch.object(self.block_to_test, 'review_subjects', patched_review_subjects):
+            patched_review_status.return_value = review_stage_state
+            patched_review_subjects.return_value = []
+
+            self.assertEqual(self.block.get_stage_state(), StageState.NOT_STARTED)
 
     def test_validation(self):
         questions = [self._make_question(graded=True)]

--- a/tests/unit/test_stages.py
+++ b/tests/unit/test_stages.py
@@ -8,6 +8,7 @@ from xblock.validation import ValidationMessage
 from group_project_v2.group_project import GroupActivityXBlock
 from group_project_v2.project_api import ProjectAPI
 from group_project_v2.stage import EvaluationDisplayStage, GradeDisplayStage, TeamEvaluationStage, PeerReviewStage
+from group_project_v2.stage.utils import ReviewState, StageState
 from group_project_v2.stage_components import PeerSelectorXBlock, GroupProjectReviewQuestionXBlock, GroupSelectorXBlock
 from tests.utils import TestWithPatchesMixin, make_review_item
 
@@ -74,7 +75,8 @@ class ReviewStageChildrenMockContextManager(object):
         return False
 
 
-class ReviewStageBaseTest(BaseStageTest):
+@ddt.ddt
+class ReviewStageBaseTest(object):
     def _make_question(self, required=False, graded=False):
         fields = {
             'grade': graded,
@@ -82,8 +84,37 @@ class ReviewStageBaseTest(BaseStageTest):
         }
         return GroupProjectReviewQuestionXBlock(self.runtime_mock, DictFieldData(fields), scope_ids=mock.Mock())
 
+    @ddt.data(
+        (False, False),
+        (True, True)
+    )
+    @ddt.unpack
+    def test_marks_visited_on_student_view(self, can_mark_complete, should_set_visited):
+        can_mark_mock = mock.PropertyMock(return_value=can_mark_complete)
+        self.assertFalse(self.block.visited)  # precondition check
+        with mock.patch.object(self.block_to_test, 'can_mark_complete', can_mark_mock):
+            self.block.student_view({})
 
-class TestTeamEvaluationStage(ReviewStageBaseTest):
+            self.assertEqual(self.block.visited, should_set_visited)
+
+    @ddt.data(
+        (ReviewState.NOT_STARTED, False, StageState.NOT_STARTED),
+        (ReviewState.INCOMPLETE, False, StageState.NOT_STARTED),
+        (ReviewState.COMPLETED, False, StageState.NOT_STARTED),
+        (ReviewState.NOT_STARTED, True, StageState.NOT_STARTED),
+        (ReviewState.INCOMPLETE, True, StageState.INCOMPLETE),
+        (ReviewState.COMPLETED, True, StageState.COMPLETED),
+    )
+    @ddt.unpack
+    def test_stage_state(self, review_stage_state, visited, expected_stage_state):
+        self.block.visited = visited
+        with mock.patch.object(self.block_to_test, 'review_status') as patched_review_status:
+            patched_review_status.return_value = review_stage_state
+
+            self.assertEqual(self.block.get_stage_state(), expected_stage_state)
+
+
+class TestTeamEvaluationStage(ReviewStageBaseTest, BaseStageTest):
     block_to_test = TeamEvaluationStage
 
     def setUp(self):
@@ -118,7 +149,7 @@ class TestTeamEvaluationStage(ReviewStageBaseTest):
         self.assertEqual(message.type, ValidationMessage.ERROR)
         self.assertIn(u"Grade questions are not supported", message.text)
 
-    def test_validtion_passes(self):
+    def test_validation_passes(self):
         questions = [self._make_question()]
         categories = [GroupProjectReviewQuestionXBlock.CATEGORY, PeerSelectorXBlock.CATEGORY]
         with ReviewStageChildrenMockContextManager(self.block, categories, questions):
@@ -128,7 +159,7 @@ class TestTeamEvaluationStage(ReviewStageBaseTest):
         self.assertEqual(len(messages), 0)
 
 
-class TestPeerReviewStage(ReviewStageBaseTest):
+class TestPeerReviewStage(ReviewStageBaseTest, BaseStageTest):
     block_to_test = PeerReviewStage
 
     def setUp(self):
@@ -163,7 +194,7 @@ class TestPeerReviewStage(ReviewStageBaseTest):
         self.assertEqual(message.type, ValidationMessage.ERROR)
         self.assertIn(u"Grade questions are required", message.text)
 
-    def test_validtion_passes(self):
+    def test_validation_passes(self):
         questions = [self._make_question(graded=True)]
         categories = [GroupProjectReviewQuestionXBlock.CATEGORY, GroupSelectorXBlock.CATEGORY]
         with ReviewStageChildrenMockContextManager(self.block, categories, questions):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,9 +2,11 @@ from mock import Mock
 import mock
 from xblockutils.resources import ResourceLoader
 from group_project_v2.api_error import ApiError
+from group_project_v2.mixins import UserAwareXBlockMixin
 
 from group_project_v2.project_api import ProjectAPI, UserDetails
 from group_project_v2.stage_components import GroupProjectReviewQuestionXBlock
+from group_project_v2.utils import ALLOWED_OUTSIDER_ROLES
 
 loader = ResourceLoader(__name__)  # pylint: disable=invalid-name
 
@@ -100,3 +102,10 @@ def make_question(question_id, title):
     question.question_id = question_id
     question.title = title
     return question
+
+
+def switch_to_ta_grading(project_api_mock, review_group_id=1):
+    project_api_mock.get_user_preferences.return_value = {
+        UserAwareXBlockMixin.TA_REVIEW_KEY: review_group_id
+    }
+    project_api_mock.get_user_roles_for_course.return_value = [{'role': role} for role in ALLOWED_OUTSIDER_ROLES]


### PR DESCRIPTION
**Depends on:** https://github.com/edx-solutions/XBlock/pull/6

**Testing instructions:**
1. TA with staff access:
1.1. Grant TA company or internal admin role. 
1.2. Make sure there's at least one TA graded activity (Min required reviews = 0 in studio for activity) with Peer Review stage. 
1.3. Go to Admin -> Group  Work -> Select Course -> Group Work Status -> Choose any group -> Click "TA Graded" in any column.
1.4. You should arrive to Group Project at selected stage. **Expected result:** Can grade group and submit feedback. **Failure condition:** clicking submit does not post feedback.
2. Copy Update - after submitting any upload, the confirmation dialog text should not contain "passes" at the end.
3. Review stages state
3.1. Review stage (both Peer Grading and team Evaluation) stages should not be marked as complete or partially complete unless student visited them first when they were opened.
4. Preserving question IDs over export-import
4.1. Create some Review Question XBlocks, but **do not edit Question ID** (or revert to default, if accidentally edited).
4.2. Add some Evaluation Display or Grade Display XBlocks to appropriate stages (Team Evaluation or Grade Display stages, respectively). Edit them and choose any question available. Make sure there are no validation error.
4.3. Export the course (depends on https://github.com/edx-solutions/XBlock/pull/6)
4.4. Import the course (as a new course or replacing existing course).
4.5. Navigate to Team Eval or Grade Display stage in Studio. **Expected result:** still no validation errors, questions are still selected. **Failure condition:** questions are not selected for Evaluation/Grade Display XBlocks, validation errors appear.
5. TA has access to Resources and Discussion views
5.1. Navigate to Group Project in TA grading mode (see 1.3)
5.2. Observe that Project Navigator shows Resources and Private Discussion selectors. 
5.3. Clicking the selectors should activate corresponding views.