### PR TITLE
Activities with pending grades are properly used when calculating course grade

### DIFF
--- a/group_project_v2/group_project.py
+++ b/group_project_v2/group_project.py
@@ -29,10 +29,10 @@ log = logging.getLogger(__name__)
 
 class GroupProjectXBlock(CommonMixinCollection, DashboardXBlockMixin, DashboardRootXBlockMixin, XBlock):
     display_name = String(
-        display_name="Display Name",
-        help="This is a name of the project",
+        display_name=_(u"Display Name"),
+        help=_(u"This is a name of the project"),
         scope=Scope.settings,
-        default="Group Project V2"
+        default=_(u"Group Project V2")
     )
 
     CATEGORY = "gp-v2-project"
@@ -229,37 +229,37 @@ class GroupActivityXBlock(
     XBlock providing a group activity project for a group of students to collaborate upon
     """
     display_name = String(
-        display_name="Display Name",
-        help="This name appears in the horizontal navigation at the top of the page.",
+        display_name=_(u"Display Name"),
+        help=_(u"This name appears in the horizontal navigation at the top of the page."),
         scope=Scope.settings,
-        default="Group Project Activity"
+        default=_(u"Group Project Activity")
     )
 
     weight = Float(
-        display_name="Weight",
-        help="This is the maximum score that the user receives when he/she successfully completes the problem",
+        display_name=_(u"Weight"),
+        help=_(u"This is the maximum score that the user receives when he/she successfully completes the problem."),
         scope=Scope.settings,
         default=100.0
     )
 
     group_reviews_required_count = Integer(
-        display_name="Reviews Required Minimum",
-        help="The minimum number of group-reviews that should be applied to a set of submissions "
-             "(set to 0 to be 'TA Graded')",
+        display_name=_(u"Reviews Required Minimum"),
+        help=_(u"The minimum number of group-reviews that should be applied to a set of submissions "
+               u"(set to 0 to be 'TA Graded')"),
         scope=Scope.settings,
         default=3
     )
 
     user_review_count = Integer(
-        display_name="User Reviews Required Minimum",
-        help="The minimum number of other-group reviews that an individual user should perform",
+        display_name=_(u"User Reviews Required Minimum"),
+        help=_(u"The minimum number of other-group reviews that an individual user should perform"),
         scope=Scope.settings,
         default=1
     )
 
     due_date = DateTime(
-        display_name="Due date",
-        help="ACtivity due date",
+        display_name=_(u"Due date"),
+        help=_(u"Activity due date"),
         has_score=Scope.settings,
         default=None
     )

--- a/group_project_v2/group_project.py
+++ b/group_project_v2/group_project.py
@@ -278,6 +278,12 @@ class GroupActivityXBlock(
         return self.scope_ids.usage_id
 
     def max_score(self):
+        """
+        Used for grading purposes:
+            * As max grade for submitting grade event. See :method:`assign_grade_to_group`
+            * As theoretical max score for grade calculation when grade is not yet available
+        :rtype: Float
+        """
         return self.weight
 
     @property
@@ -480,6 +486,12 @@ class GroupActivityXBlock(
                 self.mark_complete(user.id)
 
     def assign_grade_to_group(self, group_id, grade_value):
+        """
+        Assigns grade to group, fires required events and notifications
+        :param int group_id: Group ID
+        :param float grade_value: Grade to assign
+        :return:
+        """
         self.project_api.set_group_grade(
             group_id,
             self.course_id,

--- a/group_project_v2/group_project.py
+++ b/group_project_v2/group_project.py
@@ -277,6 +277,9 @@ class GroupActivityXBlock(
     def id(self):
         return self.scope_ids.usage_id
 
+    def max_score(self):
+        return self.weight
+
     @property
     def project(self):
         return self.get_parent()
@@ -482,7 +485,7 @@ class GroupActivityXBlock(
             self.course_id,
             self.content_id,
             grade_value,
-            self.weight
+            self.max_score()
         )
         # Emit analytics event...
         self.runtime.publish(

--- a/group_project_v2/stage_components.py
+++ b/group_project_v2/stage_components.py
@@ -41,7 +41,7 @@ class BaseGroupProjectResourceXBlock(BaseStageComponentXBlock, StudioEditableXBl
         display_name=_(u"Display Name"),
         help=_(U"This is a name of the resource"),
         scope=Scope.settings,
-        default="Group Project V2 Resource"
+        default=_(u"Group Project V2 Resource")
     )
 
     description = String(
@@ -196,7 +196,7 @@ class GroupProjectSubmissionXBlock(
         display_name=_(u"Display Name"),
         help=_(U"This is a name of the submission"),
         scope=Scope.settings,
-        default="Group Project V2 Submission"
+        default=_(u"Group Project V2 Submission")
     )
 
     description = String(
@@ -453,7 +453,7 @@ class GroupProjectReviewQuestionXBlock(BaseStageComponentXBlock, StudioEditableX
 
     title = String(
         display_name=_(u"Question text"),
-        default="",
+        default=_(u""),
         scope=Scope.content
     )
 
@@ -469,7 +469,7 @@ class GroupProjectReviewQuestionXBlock(BaseStageComponentXBlock, StudioEditableX
     question_content = String(
         display_name=_(u"Question content"),
         help=_(u"HTML control"),
-        default="",
+        default=_(u""),
         scope=Scope.content,
         multiline_editor="xml",
         xml_node=True


### PR DESCRIPTION
**Description:** If GP contains two or more activities, total course grade used to be calculated incorrectly until all activities received grade, as activities with pending grades were skipped.

**Testing instructions:**
1. Create GP with two activities (optionally of different weight), make sure weight is greater than zero for both.
2. Configure course grading (in Studio - Settings -> Grading). One grader with 100% weight is recommended. Configure section with GP to use the grader (course outline -> cog under section name -> grading section).
3. Add one Peer Grading stage with at least one question to both activities. Make sure the question highest response is equal to activity's grade (i.e. if weight is 100 and question is a dropdown, max option value should be 100).
4. Provide grade for one of the activities, but not for the other (via normal peer grading or TA grading)
5. Go to course progress page (UI navigation is yet unknown to me, just append /progress to course home page URL, i.e. `courses/Opencraft/GP2/T1/progress`).
6. Observe that the Proficiency -> Overall grade is properly calculated including wright of second activity. 
If one grader with 100% weight was used in step 2; the calculation should be: actual_activity_grade / sum_of_grade_weights. I.e. if there are two activities with equal weight, overall score should be 1/2 of first activity score.

The fix itself is in the first commit, second commit contains some improvements to field names and help texts