### PR TITLE
Removed uploader data from peer grading stage

### DIFF
--- a/group_project_v2/templates/html/components/submission_review_view.html
+++ b/group_project_v2/templates/html/components/submission_review_view.html
@@ -3,10 +3,7 @@
   <div>
     <a href="{{ upload.location }}"{% if submission.description %} title="{{ submission.description }}"{% endif %} target="_blank">{{ submission.display_name }}</a>
     {% if upload.file_name %}
-      <span class="upload_filename">({{ upload.file_name }})</span> -
-      <span class="upload_item_data">
-        {% trans "Uploaded by" %} {{ upload.user_details.user_label|safe }} on {{ upload.submission_date }}
-      </span>
+      <span class="upload_filename">({{ upload.file_name }})</span>
     {% endif %}
   </div>
 {% else %}

--- a/tests/integration/page_elements.py
+++ b/tests/integration/page_elements.py
@@ -197,13 +197,18 @@ class OtherTeamStageSubmissionsElement(BaseElement):
 class OtherTeamSubmissionElement(BaseElement):
     def __init__(self, browser, element):
         super(OtherTeamSubmissionElement, self).__init__(browser, element)
+        self._uploaded_by = None
         try:
             self.element.find_element_by_css_selector(".no_submission")
             self.no_upload = True
         except NoSuchElementException:
-            self.no_upload = False
             self._link = self.element.find_element_by_tag_name("a")
-            self._uploaded_by = self.element.find_element_by_css_selector(".upload_item_data")
+            self.no_upload = False
+
+            try:
+                self._uploaded_by = self.element.find_element_by_css_selector(".upload_item_data")
+            except NoSuchElementException:
+                pass
 
     @property
     def title(self):
@@ -227,7 +232,13 @@ class OtherTeamSubmissionElement(BaseElement):
     def uploaded_by(self):
         if self.no_upload:
             return None
-        return self._uploaded_by.text
+        if self._uploaded_by is not None:
+            return self._uploaded_by.text
+        return None
+
+    @property
+    def upload_data_available(self):
+        return self._uploaded_by is not None
 
 
 class ReviewFormElement(BaseElement):

--- a/tests/integration/test_cross_stage_features.py
+++ b/tests/integration/test_cross_stage_features.py
@@ -61,21 +61,11 @@ class TestOtherGroupSubmissionLinks(SingleScenarioTestSuite):
         budget_upload = stage1_submissions.uploads[1]
         marketing_pitch_upload = stage2_submissions.uploads[0]
 
-        def _assert_upload(upload, no_upload, title, link, filename, uploaded_by):
+        def _assert_upload(upload, no_upload, title):
             self.assertEqual(upload.no_upload, no_upload)
             self.assertEqual(upload.title, title)
-            if not no_upload:
-                self.assertEqual(upload.link, link)
-                self.assertEqual(upload.filename, filename)
-                self.assertEqual(upload.uploaded_by, uploaded_by)
+            self.assertFalse(upload.upload_data_available)
 
-        uploaded_by_tpl = "Uploaded by {user} on {date}"
-        _assert_upload(
-            issue_tree_upload, False, "Issue Tree", 'http://issue_tree.csv', 'issue_tree.csv',
-            uploaded_by_tpl.format(user=KNOWN_USERS[1].full_name, date="Jan 01")
-        )
-        _assert_upload(budget_upload, True, "Budget (This file has not been submitted by this group)", None, None, None)
-        _assert_upload(
-            marketing_pitch_upload, False, "Marketing Pitch", 'http://marketing_pitch.doc', 'marketing_pitch.doc',
-            uploaded_by_tpl.format(user=KNOWN_USERS[2].full_name, date="Jan 02")
-        )
+        _assert_upload(issue_tree_upload, False, "Issue Tree")
+        _assert_upload(budget_upload, True, "Budget (This file has not been submitted by this group)")
+        _assert_upload(marketing_pitch_upload, False, "Marketing Pitch")


### PR DESCRIPTION
**Description:** This PR makes uploader name and upload data unavailable for reviewer on peer grading stage

**Testing instructions:**
1. Create and configure Group Project with at least two groups, at least one upload and at least one peer grading stage (upload and stage should be in the same activity).
2. Generate review assignments. (MCKA Admin -> Group Work -> Choose program and course ->  Assignment Info -> Generate review assignments for at least one activity)
3. As any member of group 1, submit an upload.
4. As any member of the other group, navigate to Peer Grading stage. If there are multiple groups/teammembers, make sure you choose the right user here. You might need to try different users to pick the one that reviews that particular group. Alternatively, provide uploads for all groups.
5. Click "View team submissions".
6. Popup should not contain information about uploader and upload data.

Correct result: 
![image](https://cloud.githubusercontent.com/assets/3330048/11931566/ae9ee6e4-a820-11e5-8d08-bad5defb051b.png)

Incorrect result: 
![image](https://cloud.githubusercontent.com/assets/3330048/11931578/c5c7302e-a820-11e5-949a-8ee109b8dd30.png)

