### PR TITLE
Firefox file download fix + tests

### DIFF
--- a/group_project_v2/templates/html/components/submission_navigator_view.html
+++ b/group_project_v2/templates/html/components/submission_navigator_view.html
@@ -9,7 +9,7 @@
     <div class="upload_item_wrapper" {% if upload.location %} data-location="{{ upload.location }}" {% endif %}>
       <input
         class="{{ submission.upload_id }}_name" placeholder="Browse computer to upload file..."
-        disabled="disabled" type="text"
+        readonly="readonly" type="text"
         {% if upload.file_name %}
           value="{{ upload.file_name }}" data-original-value="{{ upload.file_name }}"
         {% endif %}

--- a/tests/integration/page_elements.py
+++ b/tests/integration/page_elements.py
@@ -469,6 +469,14 @@ class SubmissionUploadItemElement(BaseElement):
         return self.element.find_element_by_css_selector(".upload_item_wrapper").get_attribute("data-location")
 
     @property
+    def upload_item_wrapper(self):
+        return self.element.find_element_by_css_selector(".upload_item_wrapper")
+
+    @property
+    def file_upload_input(self):
+        return self.upload_item_wrapper.find_element_by_css_selector("input")
+
+    @property
     def uploaded_by(self):
         try:
             return self.element.find_element_by_css_selector(".upload_item_data").text.strip()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,8 @@
+from contextlib import contextmanager
+
 import mock
 from mock import Mock
+from selenium.webdriver.support.wait import WebDriverWait
 from xblockutils.resources import ResourceLoader
 
 from group_project_v2.api_error import ApiError
@@ -117,3 +120,28 @@ def make_workgroup(workgroup_id, users=None):
     if not users:
         users = []
     return WorkgroupDetails(id=workgroup_id, users=users)
+
+
+@contextmanager
+def expect_new_browser_window(browser, timeout=30):
+    old_window_handle = browser.current_window_handle
+
+    def new_window_available(brwsr):
+        handles = brwsr.window_handles
+        return any(handle != old_window_handle for handle in handles)
+
+    yield
+    WebDriverWait(browser, timeout).until(new_window_available, message="No window was opened")
+
+
+@contextmanager
+def switch_to_other_window(browser, other_window):
+    old_window_handle = browser.current_window_handle
+    browser.switch_to_window(other_window)
+    yield
+    browser.switch_to_window(old_window_handle)
+
+
+def get_other_windows(browser):
+    current_window_handle = browser.current_window_handle
+    return [handle for handle in browser.window_handles if handle != current_window_handle]


### PR DESCRIPTION
**Description:** This PR fixes file download issues in Firefox.
**JIRA:** [MCKIN-3711](https://edx-wiki.atlassian.net/browse/MCKIN-3711)
**Testing instructions:**
1. Create and configure group work in Studio and Apros. 
1.1. Add Group Work XBlock
1.2. Add Project Navigator and at least one Activity into Group Work XBlock
1.3. Add all Project Navigator views to Project Navigator
1.4. Add at least one Submission stage (aka Upload stage) to Activity
1.5. Add at least one Submission to Submission Stage.
2. Open group work in Apros as student.
3. Open Submissions view in Project Navigator
4. Upload a file (hint: txt, csv, xml or "office" files are usually accepted; images, css/js/html usually don't)
5. *In Firefox* - try downloading file by clicking on the filename. **Expected result:** new window is opened, URL contains filename at the end (devstack is npt configured to actually store and serve files submitted). **Error condition:** nothing happens at all.