### PR TITLE
TAs are allowed to upload files for a group

### DIFF
--- a/group_project_v2/project_navigator.py
+++ b/group_project_v2/project_navigator.py
@@ -367,7 +367,7 @@ class SubmissionsViewXBlock(ProjectNavigatorViewXBlockBase):
 
     @property
     def allow_admin_grader_access(self):
-        return False
+        return True
 
     def student_view(self, context):
         """

--- a/group_project_v2/stage_components.py
+++ b/group_project_v2/stage_components.py
@@ -235,7 +235,7 @@ class GroupProjectSubmissionXBlock(
 
     def submissions_view(self, context):
         fragment = Fragment()
-        uploading_allowed = self.stage.available_now and self.stage.is_group_member
+        uploading_allowed = (self.stage.available_now and self.stage.is_group_member) or self.stage.is_admin_grader
         render_context = {'submission': self, 'upload': self.upload, 'disabled': not uploading_allowed}
         render_context.update(context)
         fragment.add_content(loader.render_template(self.PROJECT_NAVIGATOR_VIEW_TEMPLATE, render_context))
@@ -265,7 +265,7 @@ class GroupProjectSubmissionXBlock(
             response_data = {'result': 'error', 'message': template.format(action=self.stage.STAGE_ACTION)}
             failure_code = 422  # 422 = unprocessable entity
 
-        elif not self.stage.is_group_member:
+        elif not self.stage.is_group_member and not self.stage.is_admin_grader:
             response_data = {'result': 'error', 'message': messages.NON_GROUP_MEMBER_UPLOAD}
             failure_code = 403  # 403 - forbidden
 

--- a/tests/integration/page_elements.py
+++ b/tests/integration/page_elements.py
@@ -501,6 +501,11 @@ class SubmissionUploadItemElement(BaseElement):
         except NoSuchElementException:
             return None
 
+    @property
+    def upload_enabled(self):
+        upload_ctrl = self.element.find_element_by_css_selector(".file_upload")
+        return not upload_ctrl.get_attribute('disabled')
+
     def upload_file(self, location):
         upload_item = self.element.find_element_by_css_selector(".file_upload")
         upload_item.clear()

--- a/tests/integration/test_project_navigator.py
+++ b/tests/integration/test_project_navigator.py
@@ -6,6 +6,8 @@ import textwrap
 
 import ddt
 import mock
+from datetime import datetime
+from freezegun import freeze_time
 
 from group_project_v2.project_navigator import (
     ViewTypes, ResourcesViewXBlock, SubmissionsViewXBlock, AskTAViewXBlock, PrivateDiscussionViewXBlock,
@@ -25,6 +27,7 @@ from tests.utils import (
 )
 
 
+@ddt.ddt
 class TestProjectNavigatorViews(SingleScenarioTestSuite, TestWithPatchesMixin):
     scenario = "example_1.xml"
 
@@ -171,11 +174,17 @@ class TestProjectNavigatorViews(SingleScenarioTestSuite, TestWithPatchesMixin):
         self.assertEqual(activity1_resources[3].url, "http://download/mygrading.html")
         self.assertEqual(activity1_resources[3].title, "Grading Criteria")
 
-    def test_submissions_view(self):
+    @ddt.data(True, False)
+    @freeze_time(datetime(2014, 05, 23))
+    def test_submissions_view(self, as_ta):
+        student_id = 1
+        if as_ta:
+            switch_to_ta_grading(self.project_api_mock)
+            student_id = 100
         issue_tree_loc = self.submissions['issue_tree']['document_url']
         self.project_api_mock.get_latest_workgroup_submissions_by_id.return_value = self.submissions
 
-        self._prepare_page()
+        self._prepare_page(student_id=student_id)
 
         submissions_view = self.page.project_navigator.get_view_by_type(ViewTypes.SUBMISSIONS, SubmissionsViewElement)
         self.page.project_navigator.get_view_selector_by_type(ViewTypes.SUBMISSIONS).click()
@@ -189,20 +198,16 @@ class TestProjectNavigatorViews(SingleScenarioTestSuite, TestWithPatchesMixin):
         activity1_submissions = activities[0].submissions
         issue_tree, marketing_pitch, budget = activity1_submissions
 
-        self.assertEqual(issue_tree.title, "Issue Tree")
-        self.assertEqual(issue_tree.file_location, issue_tree_loc)
-        self.assertEqual(
-            issue_tree.uploaded_by,
-            "Uploaded by {user} on {date}".format(user=KNOWN_USERS[1].full_name, date="May 22 2014")
-        )
+        def _assert_submission(submission, title, location, uploaded_by):
+            self.assertEqual(submission.title, title)
+            self.assertEqual(submission.file_location, location)
+            self.assertEqual(submission.uploaded_by, uploaded_by)
+            self.assertTrue(submission.upload_enabled)
 
-        self.assertEqual(marketing_pitch.title, "Marketing Pitch")
-        self.assertEqual(marketing_pitch.file_location, None)
-        self.assertEqual(marketing_pitch.uploaded_by, '')
-
-        self.assertEqual(budget.title, "Budget")
-        self.assertEqual(budget.file_location, None)
-        self.assertEqual(budget.uploaded_by, '')
+        issue_tree_uploaded = "Uploaded by {user} on {date}".format(user=KNOWN_USERS[1].full_name, date="May 22")
+        _assert_submission(issue_tree, "Issue Tree", issue_tree_loc, issue_tree_uploaded)
+        _assert_submission(marketing_pitch, "Marketing Pitch", None, '')
+        _assert_submission(budget, "Budget", None, '')
 
     def test_download_submission(self):
         issue_tree_loc = self.submissions['issue_tree']['document_url']

--- a/tests/integration/test_project_navigator.py
+++ b/tests/integration/test_project_navigator.py
@@ -324,9 +324,12 @@ class TestProjectNavigator(BaseIntegrationTest, TestWithPatchesMixin):
 
         self.assertEqual(
             view_types,
-            (NavigationViewXBlock.type, ResourcesViewXBlock.type, PrivateDiscussionViewXBlock.type)
+            (
+                NavigationViewXBlock.type, SubmissionsViewXBlock.type, ResourcesViewXBlock.type,
+                PrivateDiscussionViewXBlock.type
+            )
         )
         self.assertEqual(
             view_selector_types,
-            (ResourcesViewXBlock.type, PrivateDiscussionViewXBlock.type)
+            (SubmissionsViewXBlock.type, ResourcesViewXBlock.type, PrivateDiscussionViewXBlock.type)
         )

--- a/tests/unit/test_stage_components.py
+++ b/tests/unit/test_stage_components.py
@@ -186,6 +186,7 @@ class TestGroupProjectSubmissionXBlock(StageComponentXBlockTestBase):
 
     def test_upload_submission_stage_is_not_group_member(self):
         self.stage_mock.is_group_member = False
+        self.stage_mock.is_admin_grader = False
 
         response = self.block.upload_submission(mock.Mock())
         self.assertEqual(response.status_code, 403)
@@ -218,13 +219,18 @@ class TestGroupProjectSubmissionXBlock(StageComponentXBlockTestBase):
             )
 
     @ddt.data(
-        ("sub1", "file.html", "new_stage_state1"),
-        ("sub2", "other_file.so", {"activity_id": 'A1', "stage_id": 'S1', 'state': 'complete'}),
+        ("sub1", "file.html", "new_stage_state1", False),
+        ("sub2", "other_file.so", {"activity_id": 'A1', "stage_id": 'S1', 'state': 'complete'}, False),
+        ("sub1", "file_ta.so", {"activity_id": 'A1', "stage_id": 'S1', 'state': 'complete'}, True),
+        ("sub2", "other_file_ta.so", {"activity_id": 'A1', "stage_id": 'S1', 'state': 'complete'}, True),
     )
     @ddt.unpack
     @freeze_time("2015-08-01")
-    def test_upload_submission_success_scenario(self, submission_id, file_url, stage_state):
+    def test_upload_submission_success_scenario(self, submission_id, file_url, stage_state, is_admin_grader):
         upload_id = "upload_id"
+
+        self.stage_mock.is_admin_grader = is_admin_grader
+        self.stage_mock.is_group_member = not is_admin_grader
 
         request_mock = mock.Mock()
         request_mock.params = {upload_id: mock.Mock()}


### PR DESCRIPTION
**Description:** This PR enables TAs to upload files for group.

**Testing instructions:**
0. Assign a TA for a course with GPv2: as MCKA Admin go  to MCKA ADMIN -> Roles & Permissions -> select organization -> choose user -> click pencil, check "TA" in for the target course (and maybe "Internal Admin" on top of popup)
1. Log in to Apros as a TA
2. Go to MCKA ADMIN (or Internal Admin)
3. Go to Group Work tab, click "Access Admin Dashboard V2"
4. Select program, course and project
5. Click blue right arrow in any of the stages that have it (only peer grading stages have it so far, so make sure there's at least one of those)
6. Expand any group; clicking on "Group Project" icon (three "users" in circle) - Group project in TA grading mode should open
7. Make sure submissions view is available (displayed in PN) and can be opened
8. Ty uploading a file for any of the submissions. Note some file types are not allowed - csv and txt work for sure, most office files work as well.