### PR TITLE
Fix for MCKIN-3702 close date for stage now means EOD

### DIFF
--- a/group_project_v2/stage/base.py
+++ b/group_project_v2/stage/base.py
@@ -1,8 +1,7 @@
 import logging
 from collections import OrderedDict
 from urllib import urlencode
-
-from datetime import datetime
+from datetime import datetime, timedelta
 from lazy.lazy import lazy
 import pytz
 from xblock.core import XBlock
@@ -155,7 +154,12 @@ class BaseGroupActivityStage(
         if not self.is_group_member:
             return False
 
-        return (self.close_date is not None) and (self.close_date < datetime.utcnow().replace(tzinfo=pytz.UTC))
+        if self.close_date is None:
+            return False
+
+        # A stage is closed at the end of the closing day.
+
+        return self.close_date + timedelta(days=1) <= datetime.utcnow().replace(tzinfo=pytz.UTC)
 
     @property
     def completed(self):

--- a/tests/integration/test_stages.py
+++ b/tests/integration/test_stages.py
@@ -89,6 +89,12 @@ class CommonStageTest(StageTestBase):
         (datetime.datetime(2014, 6, 22), None, datetime.datetime(2015, 6, 12), "due Jun 12 2015"),
         # after close - should be closed June 12
         (datetime.datetime(2015, 6, 13), None, datetime.datetime(2015, 6, 12), "closed on Jun 12"),
+        # phase is open at the end of the close date day
+        (datetime.datetime(2015, 6, 13, 23, 59), datetime.datetime(2015, 6, 11),
+         datetime.datetime(2015, 6, 13), "due Jun 13"),
+        # phase is closed at the day after close day
+        (datetime.datetime(2015, 6, 14), datetime.datetime(2015, 6, 11),
+         datetime.datetime(2015, 6, 13), "closed on Jun 13"),
     )
     @ddt.unpack
     def test_open_close_label(self, mock_now, open_date, close_date, expected_label):


### PR DESCRIPTION
Fix for MCKIN-3702. 

Steps to reproduce: 

1. Install Apros and setup group work. 
2. Import GWv2 test curse 
3. Edit this course and set both Open Date And close Date to today
4. Observe that Peer grading phase is closed when you login as a normal user. 

Steps to verify: 

1. Install this version of the group-project v2 xblock. 
2. Observe that peer grading phase is now open. 