### PR TITLE
Fix for invalid header in TA grading view

### DIFF
--- a/group_project_v2/templates/html/stages/peer_review.html
+++ b/group_project_v2/templates/html/stages/peer_review.html
@@ -1,6 +1,10 @@
 {% load i18n %}
 {% if stage.is_admin_grader %}
+{% if stage.activity.is_ta_graded %}
 <div class="grading_override ta_graded">{% trans "Grading View" %}</div>
+{% else %}
+<div class="grading_override">{% trans "TA Grading override view" %}</div>
+{% endif %}
 {% endif %}
 
 <div class="review other_group_review" data-review-type="group_review" data-action="submit_review" data-method="POST">


### PR DESCRIPTION
Fixes MCKIN-3510. 

**Manual verification**

1. Probably you'll need apros
2. With groupwork set up ;) 
3. Download GWv2 ver 3 course (attached to OC-649) 
4. Import the course, and set up the group work.
5. Add TA student 
6. Go to Group work dashboard and start grading "TA Graded task", you should see orange "Grading View" box on top (this is intended behavior)
7. Go to  Group work dashboard and start grading "Peer review task", you should see the same box as in last point (this is the error) 

Fix verificaiton

1. Install this version of GWv2 
2. Go to  Group work dashboard and start grading "Peer review task" you should see red box with: "TA GRADING OVERRIDE VIEW". 

Running tests

1. I have added tests that verify this functionality. These tests might need some work to use proper idioms for the test framework, pointers are welcome. 

Screenshoot guide: 

On this view click "access V2 Dashboard": 

![1_023](https://cloud.githubusercontent.com/assets/112872/13042350/ca7c5e76-d3bf-11e5-88ff-ac500aee6337.png)

Then fill program, course and exercise, you should get view as below. To go do "Detail dashboard" for a given stage click blue arrow in lower right corner of the box with white background. Note that when you click on "TA GRADED" you should get orange bar, and when you select one without you should get a red bar: 

![1_024](https://cloud.githubusercontent.com/assets/112872/13042700/81d3fae6-d3c2-11e5-921b-7c187641a25e.png)

Finally to grade an activity (while being logged in as a TA!) click on one of the groups and then click the group-work symbol that is right to group name when this group is expanded: 

![mckinsey academy - chromium_025](https://cloud.githubusercontent.com/assets/112872/13042758/f73d1c2c-d3c2-11e5-96fc-a78dca7b5bee.png)
