### PR TITLE
OC-1287 Filter by company

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,58 @@ xblock-group-project-v2
 This XBLock is experimental reimplementation of [Group Project XBlock](https://github.com/edx-solutions/xblock-group-project).
 
 It does *not* work properly in LMS yet.
+
+Configuration variables
+-----------------------
+
+This block uses following configuration variables in the ``XBLOCK_SETTINGS``:
+
+    "XBLOCK_SETTINGS": {
+      "group_project_v2": {
+        "dashboard_details_url": "/admin/workgroup/dashboard/programs/{program_id}/courses/{course_id}/projects/{project_id}/details?activate_block_id={activity_id}",
+        "ta_review_url": "/courses/{course_id}/group_work/{group_id}?activate_block_id={activate_block_id}",
+        "access_dashboard_for_all_orgs_groups": ["super_admin"],
+        "access_dashboard_groups": ["client_admin"],
+        "ta_roles": ["assistant"]
+      }
+    },
+
+These settings have following meanings:
+
+* ``dashboard_details_url``: url pattern used to generate details url in the
+  dashboard. It uses following parameters in ``str.format`` style:
+
+  * ``program_id``: Id of course group this activity belong to
+  * ``course_id``: Id of course this activity belong to
+  * ``project_id``: Id of group project to show
+  * ``activity_id``: Xblock activity to show
+
+* ``ta_review_url``: url pattern used to render the review url for the TA,
+  parameters used have the same meaning as in above urlpattern,
+  with additional ``group_id``, meaning id of group of students.
+
+* ``ta_roles``: List of names of course roles user. If logged in user has any
+  role from this set for a given course, he is assumed to be a TA for that course.
+
+* ``access_dashboard_for_all_orgs_groups``: List of names of groups of users,
+  if a user belongs to any group in this list, he can access dashboard and see
+  all work groups.
+
+* ``access_dashboard_groups``: List of names of groups of users,
+  if a user belongs to any group in this list, he can access the dashboard and
+  see groups containing students from any organisation he belongs to.
+
+If both ``access_dashboard_for_all_orgs_groups`` and ``access_dashboard_role_groups``
+are empty or missing, dashboard is effectively disabled.
+
+### Example configuration
+
+    "XBLOCK_SETTINGS": {
+      "group_project_v2": {
+        "dashboard_details_url": "/admin/workgroup/dashboard/programs/{program_id}/courses/{course_id}/projects/{project_id}/details?activate_block_id={activity_id}",
+        "ta_review_url": "/courses/{course_id}/group_work/{group_id}?activate_block_id={activate_block_id}",
+        "access_dashboard_for_all_orgs_groups": ["mcka_role_mcka_admin"],
+        "access_dashboard_groups": ["mcka_role_client_admin", "mcka_role_internal_admin"],
+        "ta_roles": ["assistant"]
+      }
+    }

--- a/group_project_v2/project_api/dtos.py
+++ b/group_project_v2/project_api/dtos.py
@@ -80,3 +80,16 @@ class CompletionDetails(object):
         self.stage = kwargs.get('stage')
         self.created = kwargs.get('created')
         self.modified = kwargs.get('modified')
+
+
+class OrganisationDetails(object):
+    def __init__(self, **kwargs):
+        self.name = kwargs.get('name')
+        self.display_name = kwargs.get('display_name')
+        self.user_ids = set(kwargs.get('users'))
+
+
+class UserGroupDetails(object):
+    def __init__(self, **kwargs):
+        self.id = kwargs.get('id')
+        self.name = kwargs.get('name')

--- a/group_project_v2/public/css/group_project_dashboard.css
+++ b/group_project_v2/public/css/group_project_dashboard.css
@@ -246,6 +246,10 @@ table.activity-data tr.user-data-row {
     display: none;
 }
 
+table.activity-data tr.user-data-row.filtered-out td a{
+    color: #868685;
+}
+
 table.activity-data tr.user-data-row td.user-cell {
     padding-left: 24px;
 }

--- a/group_project_v2/stage/basic.py
+++ b/group_project_v2/stage/basic.py
@@ -9,7 +9,7 @@ from group_project_v2.api_error import ApiError
 from group_project_v2.stage.base import BaseGroupActivityStage
 from group_project_v2.stage.mixins import SimpleCompletionStageMixin
 from group_project_v2.stage_components import SubmissionsStaticContentXBlock, GroupProjectSubmissionXBlock
-from group_project_v2.utils import gettext as _, outsider_disallowed_protected_handler, loader
+from group_project_v2.utils import gettext as _, groupwork_protected_handler, loader
 from group_project_v2.stage.utils import StageState, DISPLAY_NAME_NAME, DISPLAY_NAME_HELP
 
 log = logging.getLogger(__name__)
@@ -58,7 +58,7 @@ class CompletionStage(SimpleCompletionStageMixin, BaseGroupActivityStage):
     STAGE_ACTION = _(u"mark stage as complete")
 
     @XBlock.json_handler
-    @outsider_disallowed_protected_handler
+    @groupwork_protected_handler
     def stage_completed(self, _data, _suffix=''):
         if not self.available_now:
             template = messages.STAGE_NOT_OPEN_TEMPLATE if not self.is_open else messages.STAGE_CLOSED_TEMPLATE

--- a/group_project_v2/stage/review.py
+++ b/group_project_v2/stage/review.py
@@ -18,7 +18,7 @@ from group_project_v2.stage_components import (
 )
 from group_project_v2.utils import (
     loader, gettext as _, make_key,
-    outsider_disallowed_protected_handler, key_error_protected_handler, conversion_protected_handler,
+    groupwork_protected_handler, key_error_protected_handler, conversion_protected_handler,
     MUST_BE_OVERRIDDEN, memoize_with_expiration
 )
 from group_project_v2.stage.utils import StageState, ReviewState, DISPLAY_NAME_NAME, DISPLAY_NAME_HELP
@@ -164,7 +164,7 @@ class ReviewBaseStage(BaseGroupActivityStage):
         ]
 
     @XBlock.json_handler
-    @outsider_disallowed_protected_handler
+    @groupwork_protected_handler
     @key_error_protected_handler
     @conversion_protected_handler
     def submit_review(self, submissions, _context=''):
@@ -281,7 +281,7 @@ class TeamEvaluationStage(ReviewBaseStage):
         return violations
 
     @XBlock.handler
-    @outsider_disallowed_protected_handler
+    @groupwork_protected_handler
     @key_error_protected_handler
     @conversion_protected_handler
     def load_peer_feedback(self, request, _suffix=''):
@@ -424,7 +424,7 @@ class PeerReviewStage(ReviewBaseStage):
         ta_reviews = {
             reviewer: items
             for reviewer, items in grouped_items.iteritems()
-            if self._confirm_outsider_allowed(self.project_api, self.real_user_id(reviewer), self.course_id)
+            if self.is_user_ta(self.real_user_id(reviewer), self.course_id)
         }
         return ta_reviews
 
@@ -500,7 +500,7 @@ class PeerReviewStage(ReviewBaseStage):
         return super(PeerReviewStage, self).get_stage_state()
 
     @XBlock.handler
-    @outsider_disallowed_protected_handler
+    @groupwork_protected_handler
     @key_error_protected_handler
     @conversion_protected_handler
     def other_submission_links(self, request, _suffix=''):
@@ -521,7 +521,7 @@ class PeerReviewStage(ReviewBaseStage):
         return webob.response.Response(body=json.dumps({"html": html_output}))
 
     @XBlock.handler
-    @outsider_disallowed_protected_handler
+    @groupwork_protected_handler
     @key_error_protected_handler
     def load_other_group_feedback(self, request, _suffix=''):
         group_id = int(request.GET["group_id"])

--- a/group_project_v2/stage_components.py
+++ b/group_project_v2/stage_components.py
@@ -23,7 +23,7 @@ from group_project_v2.utils import get_link_to_block, FieldValuesContextManager,
     make_user_caption
 from group_project_v2.utils import (
     outer_html, gettext as _, loader, format_date, build_date_field, mean,
-    outsider_disallowed_protected_view
+    groupwork_protected_view
 )
 
 log = logging.getLogger(__name__)
@@ -631,7 +631,7 @@ class GroupProjectBaseFeedbackDisplayXBlock(
 
         return matching_questions[0]
 
-    @outsider_disallowed_protected_view
+    @groupwork_protected_view
     def student_view(self, context):
         if self.question is None:
             return Fragment(messages.COMPONENT_MISCONFIGURED)

--- a/group_project_v2/templates/html/activity/dashboard_detail_view.html
+++ b/group_project_v2/templates/html/activity/dashboard_detail_view.html
@@ -42,7 +42,7 @@
         {% endfor %}
       </tr>
         {% for user in group.users %}
-          <tr class="user-data-row data" data-group-id="{{group.id}}" data-fullname="{{user.full_name}}" data-email="{{user.email}}">
+          <tr class="user-data-row data{% if user.is_filtered_out %} filtered-out{%endif%}" data-group-id="{{group.id}}" data-fullname="{{user.full_name}}" data-email="{{user.email}}">
             <td class="user-cell">
               <div class="user-email">
                 <a href="mailto: {{ user.email }}">{{ user.email }}</a>
@@ -69,6 +69,23 @@
           </tr>
         {% endfor %}
       {% endfor %}
+      {% if filtered_out_workgroups %}
+      <tr class="data" data-group-id="{{group.id}}" data-collapsed="collapsed">
+        <td colspan="{{stages|length|add:'1'}}">
+        {% if groups|length %}
+          {% blocktrans count counter=filtered_out_workgroups %}
+            Additionally there is a single work group filtered by company filter.
+          {% plural %}
+            Additionally there were {{counter}} work groups filtered by company filter.
+          {% endblocktrans %}
+        {% else %}
+          {% blocktrans %}
+            All work groups have been filtered by the company filter.
+          {% endblocktrans %}
+        {% endif %}
+          </td>
+        </tr>
+      {% endif %}
     </table>
   </div>
 </div>

--- a/tests/integration/test_stages.py
+++ b/tests/integration/test_stages.py
@@ -11,11 +11,10 @@ from freezegun import freeze_time
 import mock
 from workbench.runtime import WorkbenchRuntime
 
-from group_project_v2.mixins import UserAwareXBlockMixin
+from group_project_v2.mixins import UserAwareXBlockMixin, AuthXBlockMixin
 from group_project_v2.project_api.dtos import WorkgroupDetails
 from group_project_v2.stage import BasicStage, SubmissionStage, PeerReviewStage, TeamEvaluationStage
 from group_project_v2.stage.utils import ReviewState
-from group_project_v2.utils import ALLOWED_OUTSIDER_ROLES
 from tests.integration.base_test import BaseIntegrationTest
 from tests.integration.page_elements import GroupProjectElement, ReviewStageElement, ProjectTeamElement
 from tests.utils import KNOWN_USERS, OTHER_GROUPS, TestConstants, make_review_item as mri, WORKGROUP
@@ -788,7 +787,9 @@ class TestTAGradedPeerReview(BasePeerReviewStageTest):
         self.project_api_mock.get_user_preferences = mock.Mock(
             return_value={UserAwareXBlockMixin.TA_REVIEW_KEY: group_id}
         )
-        self.project_api_mock.get_user_roles_for_course = mock.Mock(return_value=[{'role': ALLOWED_OUTSIDER_ROLES[0]}])
+        self.project_api_mock.get_user_roles_for_course = mock.Mock(return_value=[
+            {'role': AuthXBlockMixin.DEFAULT_TA_ROLE[0]}  # pylint:disable=protected-access
+        ])
         self.project_api_mock.get_workgroup_by_id.side_effect = lambda g_id: WorkgroupDetails(
             id=g_id, users=[{"id": 1}]
         )
@@ -796,7 +797,7 @@ class TestTAGradedPeerReview(BasePeerReviewStageTest):
         stage_element = self.get_stage(self.go_to_view(student_id=user_id))
         self.assertTrue(stage_element.has_admin_grading_notification)
 
-        self.project_api_mock.get_workgroup_by_id.assert_called_once_with(group_id)
+        self.project_api_mock.get_workgroup_by_id.assert_called_with(group_id)
 
         self.assertEqual(len(stage_element.groups), 1)
         group = stage_element.groups[0]
@@ -863,7 +864,9 @@ class ProjectTeamBlockTest(StageTestBase):
         Ensure block shows team members.
         """
         user_id = 1
-        self.project_api_mock.get_user_roles_for_course = mock.Mock(return_value=[{'role': ALLOWED_OUTSIDER_ROLES[0]}])
+        self.project_api_mock.get_user_roles_for_course = mock.Mock(return_value=[
+            {'role': AuthXBlockMixin.DEFAULT_TA_ROLE[0]}  # pylint:disable=protected-access
+        ])
         self.project_api_mock.get_workgroup_by_id.side_effect = lambda g_id: {"id": g_id, "users": [{"id": 1}]}
         stage_element = self.get_stage(self.go_to_view(student_id=user_id), stage_element_type=ProjectTeamElement)
         self.assertEqual(stage_element.team_members, [u'Jane', u'Jack', u'Jill'])

--- a/tests/unit/test_stages/test_peer_review.py
+++ b/tests/unit/test_stages/test_peer_review.py
@@ -367,7 +367,7 @@ class TestPeerReviewStageReviewStatus(ReviewStageBaseTest, ReviewStageUserComple
             }
         )
 
-        with patch_obj(self.block, '_confirm_outsider_allowed') as patched_outsider_allowed:
-            patched_outsider_allowed.side_effect = lambda _api, user_id, _course_id: user_id in ta_reviewers
+        with patch_obj(self.block, 'is_user_ta') as patched_outsider_allowed:
+            patched_outsider_allowed.side_effect = lambda user_id, _course_id: user_id in ta_reviewers
 
             self.assert_group_completion(group_to_review, questions, expected_result)


### PR DESCRIPTION
What is done: 
- [x] Client Id is sent by GET parameter by GWv2
- [x] We have a very simple graying out logic for graying out filtered users 
- [x] Hiding groups made entirely from people from the other companies 
- [x] Filtering done for Company Admins
- [x] Company Combo-Box always show all companies, but it should only show companies participaing in designed course/programme
- [x] Fix tests

What should be done 
- [ ] Add tests 

**Post-internal review todos**
- [x] Squash commits 
- [x] Get :+1: from the devops for config changes

**Major changes in XBlock logic**

* User needs to have a specific role to access dashboard at all
* Company admins will have the detail dashboard pre-filtered by company, this person is administering, which means he will only have access to groups that contain no students from this company. This filter can't be taken down. 

**Configuration changes** 

Use following ``XBLOCK_SETTINGS``: 

	"XBLOCK_SETTINGS": {
		"group_project_v2": {
		    "dashboard_details_url": "/admin/workgroup/dashboard/programs/{program_id}/courses/{course_id}/projects/{project_id}/details?activate_block_id={activity_id}",
		    "ta_review_url": "/courses/{course_id}/group_work/{group_id}?activate_block_id={activate_block_id}",
		 "see_dashboard_for_all_orgs_perms": ["mcka_role_mcka_admin"],
		 "see_dashboard_role_perms": ["mcka_role_client_admin", "mcka_role_internal_admin"],
		 "ta_roles": ["assistant"]
		}
	}, 

**After I merge review changes** ``see_*`` will be renamed to ``access_*``. 

Testing Instructions: 

**Common steps**
0. Download Apros from this branch: https://github.com/mckinseyacademy/mcka_apros/pull/1308
1. Create 4 clients, Client1, Client2, Client3. Client4 
2. Associate Client1, 2 and 3 with a program with Group Work
3. Create three users for each Client (except for Client4 for which it is not needed)
4. Assign Clients to course with Group Work
5. Following Groups: 
 - 2 students from Client 1 (Group 1) 
 - 2 students from Client 2 and a student from Client 1 (Group 2) 
6. Set up a student from Client 2 as a company admin/internal admin for that company

**Combo box behavior**

* Note that Client 4 organisation is missing form the Combo box (as combo box contains all organisations that take part in this program). 

**Filtering for mcka_admin**
1. Login as mcka_admin_user
2. Go to detail dashboard and observe following behavior: 

  - When you select Client 3 all work groups are hidden and there is a following message: "All workgroups have been filtered by the company filter."
  - When you select Client 2 students one of the workgroups is filtered out, and students from Client1 are grayed out.
  - When you select All companies students are not grayed out at all 
  - When you select Client 2 Group 1 is hidden 
  - When you select Client 1 No groups are hidden

Note dashboard detail url called by apros (it looks something like that on my system): ``http://apros.mcka.local/courses/FooX/FooX/v3/xblock/i4x://FooX/FooX/gp-v2-project/41fe8cae0614470c9aeb72bd078b0348/view/dashboard_detail_view?activate_block_id=i4x%3A%2F%2FFooX%2FFooX%2Fgp-v2-activity%2F9f956e0072be43ac9366836d17d57a12&client_filter_id=2&_=1455270983305``

**Check that dashboard is hidden for low privileged users**

1. Login as as student user
2. Enter URL you noted in last step. 
3. Note that JSON contents are different, and contain: "Outsider Denied Access: User can&#39;t access dashboard" 

**Behavior for company admins**

1. Log in as a company admin for Company 2
2. Go to details view 
3. Notice that Group View is filtered to contain group with Company 2 and there is no combo-box filter. 
4. Enter URL you noted in two steps ago. Change filter ID in such a way that we filter using a different id than those of company 2, note that html contains: "All work groups have been filtered by the company filter." --- that is no groups are visible. 

**Test sorting**

1. Fill a Peer Review for using a student for Group 2. Note that he has a green checkmark in dashboard. 
2. Filter dashboard using both Client 1 and Client 2, note that despite being sorted up or down user still has a green checkmark. 