### PR TITLE
Status labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist
 *~
 .coverage
 coverage
+coverage.xml
 *.log
 *.log.*
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ XVFB := $(shell command -v xvfb-run 2> /dev/null)
 
 clean:
 	-rm -rf dist coverage 2> /dev/null
-	-rm .coverage tests.integration.* workbench.log 2> /dev/null
+	-rm tests.integration.* workbench.log 2> /dev/null
 
 requirements:
 	pip install -r requirements/base.txt
@@ -22,11 +22,15 @@ test: test-requirements test_fast
 test_fast:
 	./node_modules/.bin/karma start tests/js/karma.conf.js  --single-run
 ifdef XVFB
-	xvfb-run --server-args="-screen 0, 1024x800x24" ./run_tests.py --with-coverage --cover-package=group_project_v2
+	xvfb-run --server-args="-screen 0, 1920x1080x24" ./run_tests.py --with-coverage --cover-package=group_project_v2
 else
 	./run_tests.py --with-coverage --cover-package=group_project_v2
 endif
 	coverage html
+
+diff-cover:
+	coverage xml
+	diff-cover --compare-branch=master coverage.xml
 
 quality:
 	pep8 group_project_v2 tests --max-line-length=120

--- a/group_project_v2/public/css/group_project_common.css
+++ b/group_project_v2/public/css/group_project_common.css
@@ -72,3 +72,18 @@
 .group-project-stage-dates {
     color: #E37222;
 }
+
+.group-project-stage-state-label {
+    padding: 0.25em;
+    border: 1px solid #E37222;
+    border-radius: .5em;
+    background-color: #ffd;
+    color: #E37222;
+    width: 9em;
+    display: inline-block;
+}
+
+.group-project-stage-state-label.completed {
+    color: #629b2a;
+    border-color: #629b2a;
+}

--- a/group_project_v2/stage/base.py
+++ b/group_project_v2/stage/base.py
@@ -70,6 +70,8 @@ class BaseGroupActivityStage(
 
     NAVIGATION_LABEL = None
     STUDIO_LABEL = _(u"Stage")
+    EXTERNAL_STATUSES_LABEL_MAPPING = {}
+    DEFAULT_EXTERNAL_STATUS_LABEL = ""
 
     js_file = None
     js_init = None
@@ -323,6 +325,24 @@ class BaseGroupActivityStage(
         :rtype: (set[int], set[int])
         """
         raise NotImplementedError(MUST_BE_OVERRIDDEN)
+
+    def get_external_group_status(self, group):  # pylint: disable=unused-argument, no-self-use
+        """
+        Calculates external group status for the Stage.
+        Meaning of external status varies by Stage - see actual implementations docstrings.
+        :param group_project_v2.project_api.dtos.WorkgroupDetails group: workgroup
+        :rtype: StageState
+        """
+        return StageState.NOT_AVAILABLE
+
+    def get_external_status_label(self, status):
+        """
+        Gets human-friendly label for external status.
+        Label vary by stage, so consult with actual implementaiton for details
+        :param StageState status: external stage status
+        :rtype: str
+        """
+        return self.EXTERNAL_STATUSES_LABEL_MAPPING.get(status, self.DEFAULT_EXTERNAL_STATUS_LABEL)
 
     def navigation_view(self, context):
         """

--- a/group_project_v2/stage/basic.py
+++ b/group_project_v2/stage/basic.py
@@ -103,6 +103,13 @@ class SubmissionStage(BaseGroupActivityStage):
     NAVIGATION_LABEL = _(u'Task')
     STUDIO_LABEL = _(u"Deliverable")
 
+    EXTERNAL_STATUSES_LABEL_MAPPING = {
+        StageState.NOT_STARTED: _("Pending Upload"),
+        StageState.INCOMPLETE: _("Pending Upload"),
+        StageState.COMPLETED: _("Uploaded"),
+    }
+    DEFAULT_EXTERNAL_STATUS_LABEL = _("Unknown")
+
     submissions_stage = True
 
     STAGE_ACTION = _(u"upload submission")
@@ -195,18 +202,34 @@ class SubmissionStage(BaseGroupActivityStage):
         """
         completed_users = []
         partially_completed_users = []
-        upload_ids = set(submission.upload_id for submission in self.submissions)
         for group in target_workgroups:
-            group_submissions = self.project_api.get_latest_workgroup_submissions_by_id(group.id)
-            uploaded_submissions = set(group_submissions.keys())
-
-            has_all = uploaded_submissions >= upload_ids
-            has_some = bool(uploaded_submissions & upload_ids)
+            group_stage_state = self.get_external_group_status(group)
             workgroup_user_ids = [user.id for user in group.users]
 
-            if has_all:
+            if group_stage_state == StageState.COMPLETED:
                 completed_users.extend(workgroup_user_ids)
-            if has_some and not has_all:
+            if group_stage_state == StageState.INCOMPLETE:
                 partially_completed_users.extend(workgroup_user_ids)
 
         return set(completed_users), set(partially_completed_users)  # removing duplicates - just in case
+
+    def get_external_group_status(self, group):
+        """
+        Calculates external group status for the Stage.
+        For Submissions stage, external status is the same as internal one: "have workgroup submitted all uploads?"
+        :param group_project_v2.project_api.dtos.WorkgroupDetails group: workgroup
+        :rtype: StageState
+        """
+        upload_ids = set(submission.upload_id for submission in self.submissions)
+        group_submissions = self.project_api.get_latest_workgroup_submissions_by_id(group.id)
+        uploaded_submissions = set(group_submissions.keys())
+
+        has_all = uploaded_submissions >= upload_ids
+        has_some = bool(uploaded_submissions & upload_ids)
+
+        if has_all:
+            return StageState.COMPLETED
+        elif has_some:
+            return StageState.INCOMPLETE
+        else:
+            return StageState.NOT_STARTED

--- a/group_project_v2/stage/basic.py
+++ b/group_project_v2/stage/basic.py
@@ -114,6 +114,10 @@ class SubmissionStage(BaseGroupActivityStage):
         return blocks
 
     @property
+    def is_graded_stage(self):
+        return True
+
+    @property
     def submissions(self):
         """
         :rtype: collections.Iterable[GroupProjectSubmissionXBlock]

--- a/group_project_v2/stage/review.py
+++ b/group_project_v2/stage/review.py
@@ -320,6 +320,13 @@ class PeerReviewStage(ReviewBaseStage):
     CATEGORY = 'gp-v2-stage-peer-review'
     STAGE_CONTENT_TEMPLATE = 'templates/html/stages/peer_review.html'
 
+    EXTERNAL_STATUSES_LABEL_MAPPING = {
+        StageState.NOT_STARTED: _("Pending Review"),
+        StageState.INCOMPLETE: _("Pending Review"),
+        StageState.COMPLETED: _("Review Complete"),
+    }
+    DEFAULT_EXTERNAL_STATUS_LABEL = _("Unknown")
+
     STUDIO_LABEL = _(u"Peer Grading")
 
     REVIEW_ITEM_KEY = "workgroup"
@@ -428,7 +435,13 @@ class PeerReviewStage(ReviewBaseStage):
         }
         return ta_reviews
 
-    def get_group_completion(self, group):
+    def get_external_group_status(self, group):
+        """
+        Calculates external group status for the Stage.
+        For Peer Grading stage, external status means "have students in other groups provided grades to this group?"
+        :param group_project_v2.project_api.dtos.WorkgroupDetails group: workgroup
+        :rtype: StageState
+        """
         if not self.activity.is_ta_graded:
             reviewer_ids = [
                 user['id'] for user in self.project_api.get_workgroup_reviewers(group.id, self.activity_content_id)

--- a/group_project_v2/stage/utils.py
+++ b/group_project_v2/stage/utils.py
@@ -6,6 +6,7 @@ class StageState(object):
     INCOMPLETE = 'incomplete'
     COMPLETED = 'completed'
     UNKNOWN = 'unknown'
+    NOT_AVAILABLE = 'na'
 
     HUMAN_NAMES_MAP = {
         NOT_STARTED: _("Not started"),

--- a/group_project_v2/templates/html/activity/dashboard_detail_view.html
+++ b/group_project_v2/templates/html/activity/dashboard_detail_view.html
@@ -33,9 +33,11 @@
         {% for stage in stages %}
           <td>
             {% with stage_states=group.stage_states|get_item:stage.id %}
-              <span class="group-project-stage-state fa {{ stage_states.students_provided_grades }}"></span>
-              {% if stage_states.group_received_grades %}
-                <span class="group-project-stage-state fa {{ stage_states.group_received_grades }}"></span>
+              <span class="group-project-stage-state fa {{ stage_states.internal_status }}"></span>
+              {% if stage_states.external_status != StageState.NOT_AVAILABLE %}
+                <span class="group-project-stage-state-label  {{ stage_states.external_status }}">
+                  {{ stage_states.external_status_label }}
+                </span>
               {% endif %}
             {% endwith %}
           </td>

--- a/group_project_v2/utils.py
+++ b/group_project_v2/utils.py
@@ -2,6 +2,8 @@
 import csv
 import functools
 import logging
+from collections import namedtuple
+
 from datetime import date, datetime, timedelta
 import xml.etree.ElementTree as ET
 
@@ -329,3 +331,10 @@ def export_to_csv(data, target, headers=None):
 
     for row in data:
         writer.writerow(row)
+
+
+def named_tuple_with_docstring(type_name, field_names, docstring, verbose=False, rename=False):
+    named_tuple_type = namedtuple(type_name+"_", field_names, verbose=verbose, rename=rename)
+
+    wrapper_class = type(type_name, (named_tuple_type,), {"__doc__": docstring})
+    return wrapper_class

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,6 +2,7 @@ mock
 ddt
 freezegun
 selenium==2.52.0
+diff-cover
 
 -e git+https://github.com/edx/xblock-sdk.git@ffdaa80b9857c4d6b6cb7307c742bd187ef40aed#egg=xblock_sdk
 -e git+https://github.com/edx/opaque-keys.git@1254ed4d615a428591850656f39f26509b86d30a#egg=opaque-keys

--- a/tests/unit/test_stages/base.py
+++ b/tests/unit/test_stages/base.py
@@ -180,6 +180,6 @@ class ReviewStageUserCompletionStatsMixin(object):
         with patch_obj(self.block_to_test, 'required_questions', mock.PropertyMock()) as patched_questions:
             patched_questions.return_value = [make_question(q_id, 'irrelevant') for q_id in questions]
 
-            group_completion = self.block.get_group_completion(group)
+            group_completion = self.block.get_external_group_status(group)
 
         self.assertEqual(group_completion, expected_result)

--- a/tests/unit/test_stages/test_base_stage.py
+++ b/tests/unit/test_stages/test_base_stage.py
@@ -180,3 +180,9 @@ class TestBaseGroupActivityStage(BaseStageTest):
             self.block.dashboard_view(context)
 
         patched_stats.assert_called_once_with(workgroups, expected_students)
+
+    def test_get_external_group_status(self):
+        self.assertEqual(self.block.get_external_group_status('irrelevant'), StageState.NOT_AVAILABLE)
+
+    def test_get_external_status_label(self):
+        self.assertEqual(self.block.get_external_status_label('irrelevant'), self.block.DEFAULT_EXTERNAL_STATUS_LABEL)

--- a/tests/unit/test_stages/test_basic.py
+++ b/tests/unit/test_stages/test_basic.py
@@ -1,0 +1,9 @@
+from group_project_v2.stage import SubmissionStage
+from tests.unit.test_stages.base import BaseStageTest
+
+
+class TestSubmissionStage(BaseStageTest):
+    block_to_test = SubmissionStage
+
+    def test_is_graded_stage(self):
+        self.assertEqual(self.block.is_graded_stage, True)

--- a/tests/unit/test_stages/test_peer_review.py
+++ b/tests/unit/test_stages/test_peer_review.py
@@ -317,7 +317,7 @@ class TestPeerReviewStageReviewStatus(ReviewStageBaseTest, ReviewStageUserComple
         ([1, 2], ['q1', 'q2'], {GROUP_ID: ['1:q1:10:a', '1:q2:10:b', '2:q1:10:c', '2:q2:10:d']}, StageState.COMPLETED),
     )
     @ddt.unpack
-    def test_get_group_completions(self, reviewers, questions, review_items, expected_result):
+    def test_get_external_group_status(self, reviewers, questions, review_items, expected_result):
         group = mk_wg(GROUP_ID, [{"id": 1}])
         self.project_api_mock.get_workgroup_reviewers.return_value = [{'id': user_id} for user_id in reviewers]
 
@@ -355,7 +355,7 @@ class TestPeerReviewStageReviewStatus(ReviewStageBaseTest, ReviewStageUserComple
         ([1, 2], ['q1', 'q2'], {GROUP_ID: ['1:q1:10:a', '1:q2:10:b', '2:q2:10:c', '2:q2:10:d']}, StageState.COMPLETED),
     )
     @ddt.unpack
-    def test_ta_get_group_completions(self, ta_reviewers, questions, review_items, expected_result):
+    def test_ta_get_external_group_status(self, ta_reviewers, questions, review_items, expected_result):
         group_to_review = mk_wg(GROUP_ID, [{"id": 1}])
         self.activity_mock.is_ta_graded = True
 


### PR DESCRIPTION
**Description:** This PR switches "external" status display to using labels instead of icons and enables Submission Stages display in dashboard detail view.

**JIRA:** [MCKIN-3841](https://edx-wiki.atlassian.net/browse/MCKIN-3841), [MCKIN-3842](https://edx-wiki.atlassian.net/browse/MCKIN-3842)

**Testing instructions:**
0. Configure Group Project (see docs in `documentation` branch).
1. Log in to Apros as admin.
2. Go to MCKA ADMIN -> Group Project -> Access V2 Dashboard.
3. Choose Program, course and project - dashboard view should be diplayed
4. *New in this PR:* Submission stages should now have white background and blue arrow in bottom-right corner.
5. Click on any of the blue arrows to jump to dashboard details view
6. *New in this PR:* Submission and Peer Grading stage should display status label in addition to status icons
6.1. For Submission stage it just verbally repeats the status icon: "Uploaded" for groups completed all required uploads, "Pending Upload" otherwise.
6.2. For Peer Grading stage, status icon and status label show different information. Status icon displays "internal" status - "have all the students in this group provided grades to groups assigned for review?", while status label displays "external" status - "have students in other groups (or TAs) provided enough reviews for this group to be graded?"

Screenshots:
* TA graded activity:
![image](https://cloud.githubusercontent.com/assets/3330048/13255449/4ba445f2-da57-11e5-8b4c-f7937e63fee8.png)

* Peer graded activity:
![image](https://cloud.githubusercontent.com/assets/3330048/13255482/644a2608-da57-11e5-8d0b-2e8453505f26.png)

