### PR TITLE
file upload notification url should have stage location instead of activity

### DIFF
--- a/group_project_v2/notifications.py
+++ b/group_project_v2/notifications.py
@@ -144,11 +144,11 @@ class StageNotificationsMixin(object):
             for timer_suffix in (NotificationTimers.OPEN, NotificationTimers.DUE, NotificationTimers.COMING_DUE):
                 notifications_service.cancel_timed_notification(self._get_stage_timer_name(timer_suffix))
 
-
-class ActivityNotificationsMixin(object):
-    # While we *should* send notification, if there is some error here, we don't want to blow the whole thing up.
     @log_and_suppress_exceptions
     def fire_file_upload_notification(self, notifications_service):
+
+        log.info('{}.fire_file_upload_notification on location = {}'.format(self.__class__.__name__, self.location))
+
         # this NotificationType is registered in the list of default Open edX Notifications
         msg_type = notifications_service.get_notification_type(NotificationMessageTypes.FILE_UPLOADED)
 
@@ -167,7 +167,7 @@ class ActivityNotificationsMixin(object):
             payload={
                 '_schema_version': 1,
                 'action_username': uploader_username,
-                'activity_name': self.display_name,
+                'activity_name': self.activity.display_name,
             }
         )
         location = unicode(self.location) if self.location else ''
@@ -177,6 +177,8 @@ class ActivityNotificationsMixin(object):
         # will have only a very small handful of workgroup users
         notifications_service.bulk_publish_notification_to_users(workgroup_user_ids, msg)
 
+
+class ActivityNotificationsMixin(object):
     # While we *should* send notification, if there is some error here, we don't want to blow the whole thing up.
     @log_and_suppress_exceptions
     def fire_grades_posted_notification(self, group_id, notifications_service):

--- a/group_project_v2/stage_components.py
+++ b/group_project_v2/stage_components.py
@@ -357,7 +357,7 @@ class GroupProjectSubmissionXBlock(
         # in the list of services
         notifications_service = self.runtime.service(self, 'notifications')
         if notifications_service:
-            activity.fire_file_upload_notification(notifications_service)
+            self.stage.fire_file_upload_notification(notifications_service)
 
         return uploaded_file
 

--- a/tests/unit/test_stage_components.py
+++ b/tests/unit/test_stage_components.py
@@ -299,7 +299,7 @@ class TestGroupProjectSubmissionXBlock(StageComponentXBlockTestBase):
     def test_persist_and_submit_file_success_path(self, upload_id):
         self.block.upload_id = upload_id
         self.stage_mock.activity.content_id = 'content_id 12'
-        self.stage_mock.activity.fire_file_upload_notification = mock.Mock()
+        self.stage_mock.fire_file_upload_notification = mock.Mock()
         context_mock = mock.Mock()
         file_stream_mock = mock.Mock()
 
@@ -333,7 +333,7 @@ class TestGroupProjectSubmissionXBlock(StageComponentXBlockTestBase):
                 }
             )
 
-            self.stage_mock.activity.fire_file_upload_notification.assert_called_with(notification_service_mock)
+            self.stage_mock.fire_file_upload_notification.assert_called_with(notification_service_mock)
 
 
 @ddt.ddt


### PR DESCRIPTION
@e-kolpakov This PR fixes issue related to wrong notification urls being generated for `open-edx.xblock.group-project-v2.file-uploaded` messages. As we discussed yesterday moving file upload notification to `StageNotificationsMixin` fixes the issue. Please review.