### PR TITLE
send timed notifications for grades-posted activity

### DIFF
--- a/group_project_v2/group_project.py
+++ b/group_project_v2/group_project.py
@@ -2,9 +2,9 @@
 import logging
 import itertools
 from operator import itemgetter
+from datetime import datetime
 
 import webob
-from datetime import datetime
 from lazy.lazy import lazy
 from opaque_keys import InvalidKeyError
 from xblock.core import XBlock
@@ -441,6 +441,18 @@ class GroupActivityXBlock(
         stages = self.get_children_by_category(PeerReviewStage.CATEGORY)
         return list(self._chain_questions(stages, 'questions'))
 
+    @property
+    def grade_display_stages(self):
+        return self.get_children_by_category(GradeDisplayStage.CATEGORY)
+
+    @property
+    def max_grade_display_date(self):
+        """
+        Gets max grade display date.
+        """
+        stage_open_dates = [stage.open_date for stage in self.grade_display_stages if stage.open_date]
+        return max(stage_open_dates) if stage_open_dates else None
+
     def dashboard_details_url(self):
         """
         Gets dashboard details view URL for current activity. If settings service is not available or does not provide
@@ -793,7 +805,7 @@ class GroupActivityXBlock(
         )
         notifications_service = self.runtime.service(self, 'notifications')
         if notifications_service:
-            self.fire_grades_posted_notification(group_id, notifications_service)
+            self.fire_grades_posted_notification(group_id, notifications_service, self.max_grade_display_date)
 
     def calculate_grade(self, group_id):  # pylint:disable=too-many-locals,too-many-branches
         review_item_data = self.project_api.get_workgroup_review_items_for_group(group_id, self.content_id)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+from datetime import datetime
 
 import mock
 from mock import Mock
@@ -171,6 +172,10 @@ def switch_to_other_window(browser, other_window):
 def get_other_windows(browser):
     current_window_handle = browser.current_window_handle
     return [handle for handle in browser.window_handles if handle != current_window_handle]
+
+
+def parse_datetime(datetime_string):
+    return datetime.strptime(datetime_string, "%Y-%m-%d %H:%M:%S") if datetime_string else None
 
 
 # pylint:disable=no-self-use


### PR DESCRIPTION
@e-kolpakov this PR modifies `ActivityNotificationsMixin` to send timed notifications for `grades-posted` events. Time of notification is calculated by enumerating stages of activity for oldest grade display stage date. Could you please review this one?