### PR TITLE
notifications should not be ignored

### DIFF
--- a/group_project_v2/notifications.py
+++ b/group_project_v2/notifications.py
@@ -202,7 +202,11 @@ class ActivityNotificationsMixin(object):
         location = unicode(self.location) if self.location else ''
         add_click_link_params(msg, unicode(self.course_id), location)
 
-        send_at_date = send_at_date if send_at_date else datetime.now()
+        ignore_if_past_due = True
+        if not send_at_date:
+            send_at_date = datetime.now()
+            ignore_if_past_due = False
+
         send_at_date_tz = send_at_date.replace(tzinfo=pytz.UTC)
         notifications_service.publish_timed_notification(
             msg=msg,
@@ -212,5 +216,5 @@ class ActivityNotificationsMixin(object):
                 'workgroup_id': group_id,
             },
             timer_name=self._get_activity_timer_name(NotificationTimers.GRADE),
-            ignore_if_past_due=True  # don't send if we're already late!
+            ignore_if_past_due=ignore_if_past_due  # don't send if we're already late!
         )

--- a/tests/unit/test_notifications.py
+++ b/tests/unit/test_notifications.py
@@ -167,6 +167,7 @@ class TestActivityNotificationsMixin(BaseNotificationsTestCase, TestWithPatchesM
             self.assertEqual(kwargs['scope_name'], NotificationScopes.WORKGROUP)
             self.assertEqual(kwargs['scope_context'], {'workgroup_id': group_id})
             self.assertIsNotNone(kwargs['send_at'])
+            self.assertEqual(kwargs['ignore_if_past_due'], bool(send_at))
             message = kwargs['msg']
             self.assertEqual(message.msg_type.name, NotificationMessageTypes.GRADES_POSTED)
             self.assertEqual(message.namespace, unicode(course_id))


### PR DESCRIPTION
Notifications seems to be ignored when we set `send_at` to current datetime due to this statement
https://github.com/edx/edx-notifications/blob/master/edx_notifications/lib/publisher.py#L254

I'm not setting `ignore_if_past_due` to `False` to avoid notifications being ignored.
@e-kolpakov could you please review?.