### PR TITLE
Replace envelope icon with download icon

### DIFF
--- a/group_project_v2/public/css/group_project_dashboard.css
+++ b/group_project_v2/public/css/group_project_dashboard.css
@@ -200,13 +200,13 @@ table.activity-data tr.legend .assigned_to_groups_label {
     font-weight: 600;
 }
 
-table.activity-data tr.legend .email_icon_explanation {
+table.activity-data tr.legend .download_icon_explanation {
     margin-top: 10px;
     color: #868685;
     font-size: 12px;
 }
 
-table.activity-data tr.legend .email_icon_explanation .email_icon {
+table.activity-data tr.legend .download_icon_explanation .download_icon {
     color: #3384CA;
     font-family: FontAwesome;
 }

--- a/group_project_v2/templates/html/activity/dashboard_detail_view.html
+++ b/group_project_v2/templates/html/activity/dashboard_detail_view.html
@@ -13,8 +13,8 @@
       <tr class="legend">
         <td>
           <div class="assigned_to_groups_label">{{ assigned_to_groups_label }}</div>
-          <div class="email_icon_explanation">
-            <span class="email_icon fa fa-icon fa-envelope-o"></span> {% trans "will export a list of emails within stage of partially complete/incomplete teams" %}
+          <div class="download_icon_explanation">
+            <span class="download_icon fa fa-icon fa-download"></span> {% trans "will export a list of emails within stage of partially complete/incomplete teams" %}
           </div>
         </td>
         {% for stage in stages %}

--- a/group_project_v2/templates/html/stages/dashboard_detail_view.html
+++ b/group_project_v2/templates/html/stages/dashboard_detail_view.html
@@ -3,7 +3,7 @@
   <div class="stage-data">
     <div>
       <a href="{{ download_incomplete_emails_handler_url }}">
-        <span class="email_icon fa fa-icon fa-envelope-o"></span>
+        <span class="download_icon fa fa-icon fa-download"></span>
       </a>
     </div>
     <div class="group-project-stage-title">{{ stage.display_name }}</div>

--- a/tests/js/fixtures/dashboard_detail_view.html
+++ b/tests/js/fixtures/dashboard_detail_view.html
@@ -23,8 +23,8 @@
             <tr class="legend">
               <td>
                 <div class="assigned_to_groups_label">This project is assigned to 3 group(s)</div>
-                <div class="email_icon_explanation">
-                  <span class="email_icon fa fa-icon fa-envelope-o"></span> will export a list of emails within stage of
+                <div class="download_icon_explanation">
+                  <span class="download_icon fa fa-icon fa-download"></span> will export a list of emails within stage of
                   partially complete/incomplete teams
                 </div>
               </td>
@@ -38,7 +38,7 @@
                     <div class="stage-data">
                       <div>
                         <a href="/courses/McKinsey/GP2/T1/xblock/i4x:;_;_McKinsey;_GP2;_gp-v2-project;_41fe8cae0614470c9aeb72bd078b0348/handler/download_incomplete_list?activate_block_id=i4x%3A%2F%2FMcKinsey%2FGP2%2Fgp-v2-stage-peer-review%2Ffcfb30daabb0469eb258ce3d9c0179e9">
-                          <span class="email_icon fa fa-icon fa-envelope-o"></span>
+                          <span class="download_icon fa fa-icon fa-download"></span>
                         </a>
                       </div>
                       <div class="group-project-stage-title">Peer Grading</div>


### PR DESCRIPTION
JIRA: OC-1439

Simple swap of one Font Awesome icon for another.

Before:
![screen shot 2016-03-15 at 4 34 38 pm](https://cloud.githubusercontent.com/assets/945577/13797623/33a2578e-eacc-11e5-8936-f74a09d5c287.png)

After:
![screen shot 2016-03-15 at 4 34 47 pm](https://cloud.githubusercontent.com/assets/945577/13797625/3970fd6e-eacc-11e5-9ce9-b9192492c00e.png)