### PR TITLE
Fix for MCKIN-1446 upload stage is not showing as graded stage.

### DIFF
--- a/group_project_v2/group_project.py
+++ b/group_project_v2/group_project.py
@@ -595,7 +595,7 @@ class GroupActivityXBlock(
         stages = []
         stage_stats = {}
         for stage in self.stages:
-            if not stage.is_graded_stage:
+            if not stage.shown_on_detail_view:
                 continue
             stage_fragment = stage.render('dashboard_detail_view', children_context)
             stage_fragment.add_frag_resources(fragment)

--- a/group_project_v2/stage/base.py
+++ b/group_project_v2/stage/base.py
@@ -182,7 +182,22 @@ class BaseGroupActivityStage(
 
     @property
     def is_graded_stage(self):  # pylint: disable=no-self-use
+        """
+        If a stage is graded it is shown as graded on the the main dashboard, this property also is used by default
+        implementation of ``shown_on_detail_view``.
+
+        :rtype: bool
+        """
         return False
+
+    @property
+    def shown_on_detail_view(self):
+        """
+        If true details of this stage are shown on the dashboard detail view, by default it returns ``is_graded_stage``.
+
+        :rtype: bool
+        """
+        return self.is_graded_stage
 
     @property
     def dashboard_details_view_url(self):

--- a/group_project_v2/stage/basic.py
+++ b/group_project_v2/stage/basic.py
@@ -122,6 +122,10 @@ class SubmissionStage(BaseGroupActivityStage):
 
     @property
     def is_graded_stage(self):
+        return False
+
+    @property
+    def shown_on_detail_view(self):  # pylint: disable=no-self-use
         return True
 
     @property

--- a/tests/unit/test_stages/test_base_stage.py
+++ b/tests/unit/test_stages/test_base_stage.py
@@ -88,6 +88,12 @@ class TestBaseGroupActivityStage(BaseStageTest):
         super(TestBaseGroupActivityStage, self).setUp()
         self.render_template_patch = self.make_patch(self.block, 'render_template')
 
+    def test_stage_is_not_graded(self):
+        self.assertFalse(self.block.is_graded_stage)
+
+    def test_stage_is_not_shown_on_detail_dashboard(self):
+        self.assertFalse(self.block.shown_on_detail_view)
+
     # invalid name in order to match camlCase naming of assertSomething methods
     def assertDictionaryEqual(self, actual, expected, strict=False):  # pylint: disable=invalid-name
         """

--- a/tests/unit/test_stages/test_basic.py
+++ b/tests/unit/test_stages/test_basic.py
@@ -1,9 +1,0 @@
-from group_project_v2.stage import SubmissionStage
-from tests.unit.test_stages.base import BaseStageTest
-
-
-class TestSubmissionStage(BaseStageTest):
-    block_to_test = SubmissionStage
-
-    def test_is_graded_stage(self):
-        self.assertEqual(self.block.is_graded_stage, True)

--- a/tests/unit/test_stages/test_peer_review.py
+++ b/tests/unit/test_stages/test_peer_review.py
@@ -18,6 +18,12 @@ from tests.unit.test_stages.utils import GROUP_ID, USER_ID, OTHER_USER_ID, OTHER
 class TestPeerReviewStage(ReviewStageBaseTest, BaseStageTest):
     block_to_test = PeerReviewStage
 
+    def test_stage_is_graded(self):
+        self.assertTrue(self.block.is_graded_stage)
+
+    def test_stage_is_shown_on_detail_dashboard(self):
+        self.assertTrue(self.block.shown_on_detail_view)
+
     @ddt.data(
         *itertools.product(
             (ReviewState.NOT_STARTED, ReviewState.INCOMPLETE, ReviewState.COMPLETED),

--- a/tests/unit/test_stages/test_submission.py
+++ b/tests/unit/test_stages/test_submission.py
@@ -18,6 +18,12 @@ class TestSubmissionStage(BaseStageTest):
         self.submissions_mock = mock.PropertyMock()
         self.make_patch(self.block_to_test, 'submissions', self.submissions_mock)
 
+    def test_stage_is_not_graded(self):
+        self.assertFalse(self.block.is_graded_stage)
+
+    def test_stage_is_shown_on_detail_dashboard(self):
+        self.assertTrue(self.block.shown_on_detail_view)
+
     @ddt.data(
         # no submissions at all - not started
         (['u1'], [mk_wg(1, [{'id': 1}])], {}, (set(), set())),


### PR DESCRIPTION
### Test instructions: 

1. Have an apros devstack set up. 
2. Install a GWv2 showcase course and set it up. 
3. Login as admin user, and go to the GWv2 dashboard. Note that Upload stage now displays as grayed out. 
4. Go to Detail dashboard and note that upload stage is still displayed on the detail view. 


### Screenshots: 

#### Upload stage: 
![1_001](https://cloud.githubusercontent.com/assets/112872/14114345/e0600402-f5d6-11e5-9ad6-5d639080146b.png)

#### Detail stage

![1_002](https://cloud.githubusercontent.com/assets/112872/14114351/e8c5b9d4-f5d6-11e5-9e59-bec42fe93252.png)
