### PR TITLE
When there is no students in groups inform user of this

### DIFF
--- a/group_project_v2/public/css/group_project_dashboard.css
+++ b/group_project_v2/public/css/group_project_dashboard.css
@@ -111,6 +111,7 @@
 .group-project-xblock-wrapper .stage.dashboard-view .group-project-stage-stats td.group-project-stage-stat-value {
     color: #000;
     font-weight: bold;
+    text-align: right;
 }
 
 .group-project-xblock-wrapper .stage.dashboard-view .group-project-stage-navigate-to-detailed-view {

--- a/group_project_v2/templates/html/stages/dashboard_view.html
+++ b/group_project_v2/templates/html/stages/dashboard_view.html
@@ -17,7 +17,14 @@
     {% for stat_label, stat_value in stats.items %}
       <tr class="group-project-stage-stat">
         <td class="group-project-stage-stat-label">{{ stat_label }}</td>
-        <td class="group-project-stage-stat-value">{{ stat_value|floatformat:"0" }}%</td>
+        <td class="group-project-stage-stat-value">
+          {% if stat_value != None %}
+            {{ stat_value|floatformat:"0" }}%
+          {% else %}
+            {# &#8709 is a HTML entity for empty set #}
+            <span title="{% trans "No students match search criteria" %}">&#8709;</span>
+          {% endif %}
+        </td>
       </tr>
     {% endfor %}
   </table>

--- a/group_project_v2/templates/html/stages/dashboard_view.html
+++ b/group_project_v2/templates/html/stages/dashboard_view.html
@@ -19,7 +19,7 @@
         <td class="group-project-stage-stat-label">{{ stat_label }}</td>
         <td class="group-project-stage-stat-value">
           {% if stat_value != None %}
-            {{ stat_value|floatformat:"0" }}%
+            {{ stat_value|floatformat:"0" }} %
           {% else %}
             {# &#8709 is a HTML entity for empty set #}
             <span title="{% trans "No students match search criteria" %}">&#8709;</span>


### PR DESCRIPTION
#. Verification

1. Have working solutions devstack. 
2. Have Group Work 2 configured. 
3. Have a Program Foo, to which Group Work course named Course Foo belong
4. You need to have two companies: 
 a. One with some students attached to a group project (company A)
 b. One without students attached to this project, but company should be participating in a Program A. (Company B)
5. Go to GWv2 dashboard, select program, course, project, and select Company A, observe that stats add to 100%. 
6. Select company B, and observe that stats don't add to 100%, and look like that: 
![selection_002](https://cloud.githubusercontent.com/assets/112872/14648196/5ee0d780-0661-11e6-9859-13dcd610f7a2.png)

#. Testing

7. Check out this branch, go to GWv2 and select Company B, observe that you see stats with empty set symbol, and a tooltip explaining situation. 
![selection_004](https://cloud.githubusercontent.com/assets/112872/14648264/b0c3088e-0661-11e6-9091-432fd6b93988.png)
