### PR TITLE
Don't prefix server address if url is absolute

### DIFF
--- a/group_project_v2/project_api/api_implementation.py
+++ b/group_project_v2/project_api/api_implementation.py
@@ -5,7 +5,7 @@ import itertools
 
 from group_project_v2.api_error import api_error_protect
 from group_project_v2.json_requests import DELETE, GET, PUT, POST
-from group_project_v2.utils import memoize_with_expiration, build_date_field
+from group_project_v2.utils import memoize_with_expiration, build_date_field, is_absolute
 from group_project_v2.project_api.dtos import (
     UserDetails, ProjectDetails, WorkgroupDetails, CompletionDetails,
     OrganisationDetails, UserGroupDetails
@@ -38,12 +38,11 @@ class ProjectAPI(object):
         self.dry_run = dry_run
 
     def build_url(self, url_parts, query_params=None, no_trailing_slash=False):
-        url_template = "{}/" + "{}/" * len(url_parts)
-        url_parameters = [self._api_server_address]
-        url_parameters.extend(url_parts)
-        url = url_template.format(*url_parameters)  # pylint: disable=star-args
-        if no_trailing_slash:
-            url = url[:-1]
+        url = "/".join(url_parts)
+        if not is_absolute(url):
+            url = self._api_server_address + "/" + url
+        if not no_trailing_slash:
+            url += "/"
         if query_params:
             url += "?" + urlencode(query_params)
 

--- a/group_project_v2/utils.py
+++ b/group_project_v2/utils.py
@@ -2,6 +2,7 @@
 import csv
 import functools
 import logging
+import urlparse
 from collections import namedtuple
 
 from datetime import date, datetime, timedelta
@@ -338,3 +339,11 @@ def named_tuple_with_docstring(type_name, field_names, docstring, verbose=False,
 
     wrapper_class = type(type_name, (named_tuple_type,), {"__doc__": docstring})
     return wrapper_class
+
+
+def is_absolute(url):
+    """
+    :param url[str] url to asses
+    Returns a boolean value indicating if given `url` is absolute or not.
+    """
+    return bool(urlparse.urlparse(url).netloc)

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -3,6 +3,7 @@ ddt
 freezegun
 selenium==2.52.0
 diff-cover
+django-nose==1.4.1
 
 -e git+https://github.com/edx/xblock-sdk.git@ffdaa80b9857c4d6b6cb7307c742bd187ef40aed#egg=xblock_sdk
 -e git+https://github.com/edx/opaque-keys.git@1254ed4d615a428591850656f39f26509b86d30a#egg=opaque-keys

--- a/tests/unit/project_api/test_project_api.py
+++ b/tests/unit/project_api/test_project_api.py
@@ -47,8 +47,10 @@ class TestProjectApi(TestCase, TestWithPatchesMixin):
     @ddt.data(
         (["part1", "part2"], None, False, api_server_address+"/part1/part2/", {'error': True}),
         (["part1", "part2"], None, True, api_server_address+"/part1/part2", {'success': True}),
+        ([api_server_address, "part1", "part2"], None, False, api_server_address+"/part1/part2/", {'success': True}),
         (["part1", "part2", "part3"], None, False, api_server_address+"/part1/part2/part3/", {'error': True}),
         (["part1"], {'qwe': 'rty'}, False, api_server_address+"/part1/?qwe=rty", {'success': True, 'data': [1, 2, 3]}),
+        ([api_server_address, "part1"], {'qwe': 'rty'}, False, api_server_address+"/part1/?qwe=rty", {}),
         (["part1"], {'qwe': 'rty', 'asd': 'zxc'}, False, api_server_address+"/part1/?qwe=rty&asd=zxc", {}),
         (["part1"], {'qwe': 'rty', 'asd': 'zxc'}, True, api_server_address+"/part1?qwe=rty&asd=zxc", {}),
     )


### PR DESCRIPTION
This PR has changes to stop prefixing of server address to a url if url is absolute. It fixes a bug report in https://openedx.atlassian.net/browse/YONK-448

I had to set django-nose to 1.4.1 explicitly since requirements in xblock-sdk install 1.4.4 which breaks running of python tests since django-nose 1.4.4 does not support old versions(< 1.8) of django.

@e-kolpakov would you please review this?
