### PR TITLE
type cast url_parts to string

### DIFF
--- a/group_project_v2/project_api/api_implementation.py
+++ b/group_project_v2/project_api/api_implementation.py
@@ -38,7 +38,7 @@ class ProjectAPI(object):
         self.dry_run = dry_run
 
     def build_url(self, url_parts, query_params=None, no_trailing_slash=False):
-        url = "/".join(url_parts)
+        url = "/".join([str(url_part) for url_part in url_parts])
         if not is_absolute(url):
             url = self._api_server_address + "/" + url
         if not no_trailing_slash:

--- a/tests/unit/project_api/test_project_api.py
+++ b/tests/unit/project_api/test_project_api.py
@@ -47,6 +47,8 @@ class TestProjectApi(TestCase, TestWithPatchesMixin):
     @ddt.data(
         (["part1", "part2"], None, False, api_server_address+"/part1/part2/", {'error': True}),
         (["part1", "part2"], None, True, api_server_address+"/part1/part2", {'success': True}),
+        (["part1", 1234, "part2"], None, True, api_server_address+"/part1/1234/part2", {'error': True}),
+        (["part1", "part2", 1234], None, True, api_server_address+"/part1/part2/1234", {'success': True}),
         ([api_server_address, "part1", "part2"], None, False, api_server_address+"/part1/part2/", {'success': True}),
         (["part1", "part2", "part3"], None, False, api_server_address+"/part1/part2/part3/", {'error': True}),
         (["part1"], {'qwe': 'rty'}, False, api_server_address+"/part1/?qwe=rty", {'success': True, 'data': [1, 2, 3]}),


### PR DESCRIPTION
@e-kolpakov PR #108 introduced a glitch which break building of url when any or the `url_parts` has a non-string value. This PR fixes that glitch.
Here is the traceback or the error.
```
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 132, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/decorators.py", line 145, in inner
    return func(*args, **kwargs)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/module_render.py", line 1189, in xblock_view
    fragment = instance.render(view_name, context=request.GET)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/xblock/core.py", line 193, in render
    return self.runtime.render(self, view, context)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 2033, in render
    return self.__getattr__('render')(block, view_name, context)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 1298, in render
    return super(MetricsMixin, self).render(block, view_name, context=context)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/xblock/runtime.py", line 806, in render
    frag = view_fn(context)
  File "/edx/src/xblock-group-project-v2/group_project_v2/utils.py", line 122, in wrapper
    return func(*args, **kwargs)
  File "/edx/src/xblock-group-project-v2/group_project_v2/group_project.py", line 125, in student_view
    'group_id': self.workgroup.id
  File "/edx/src/xblock-group-project-v2/group_project_v2/mixins.py", line 369, in workgroup
    user_prefs = self.user_preferences
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/lazy/lazy.py", line 28, in __get__
    value = self.__func(inst)
  File "/edx/src/xblock-group-project-v2/group_project_v2/mixins.py", line 107, in user_preferences
    return self.project_api.get_user_preferences(self.user_id)
  File "/edx/src/xblock-group-project-v2/group_project_v2/utils.py", line 243, in wrapper
    result = func(*args, **kwargs)
  File "/edx/src/xblock-group-project-v2/group_project_v2/project_api/api_implementation.py", line 78, in get_user_preferences
    return self.send_request(GET, (USERS_API, user_id, 'preferences'), no_trailing_slash=True)
  File "/edx/src/xblock-group-project-v2/group_project_v2/project_api/api_implementation.py", line 67, in send_request
    url = self.build_url(url_parts, query_params, no_trailing_slash)
  File "/edx/src/xblock-group-project-v2/group_project_v2/project_api/api_implementation.py", line 41, in build_url
    url = "/".join(url_parts)
TypeError: sequence item 1: expected string, int found
```