### PR TITLE
fix to accommodate paginated result returned by projects API

### DIFF
--- a/group_project_v2/project_api/api_implementation.py
+++ b/group_project_v2/project_api/api_implementation.py
@@ -273,11 +273,11 @@ class TypedProjectAPI(ProjectAPI):
             'course_id': course_id
         }
         response = self.send_request(GET, (PROJECTS_API,), query_params=query_params)
-        assert len(response) <= 1
-        if not response:
+        assert len(response['results']) <= 1
+        if not response['results']:
             return None
 
-        project = response[0]
+        project = response['results'][0]
         return ProjectDetails(**project)
 
     @memoize_with_expiration()

--- a/tests/unit/project_api/canned_responses.py
+++ b/tests/unit/project_api/canned_responses.py
@@ -1,21 +1,79 @@
 class Projects(object):
     project1 = {
-        "id": 1,
-        "url": "/api/server/projects/1/",
-        "created": None, "modified": None,
-        "course_id": "MyCompany/GP2/T2",
-        "content_id": "i4x://MyCompany/GP2/gp-v2-project/abcdefghijklmnopqrstuvwxyz12345",
-        "organization": "Org1",
-        "workgroups": [1, 2, 3]
+        "count": 1,
+        "num_pages": 1,
+        "current_page": 1,
+        "results": [
+            {
+                "id": 1,
+                "url": "/api/server/projects/1/",
+                "created": None, "modified": None,
+                "course_id": "MyCompany/GP2/T2",
+                "content_id": "i4x://MyCompany/GP2/gp-v2-project/abcdefghijklmnopqrstuvwxyz12345",
+                "organization": "Org1",
+                "workgroups": [1, 2, 3]
+            }
+        ],
+        "next": None,
+        "start": 0,
+        "previous": None
     }
     project2 = {
-        "id": 2,
-        "url": "/api/server/projects/2/",
-        "created": "2015-08-04T13:26:01Z", "modified": "2015-08-04T13:26:01Z",
-        "course_id": "course1",
-        "content_id": "i4x://MyCompany/GP2/gp-v2-project/41fe8cae0614470c9aeb72bd078b0348",
-        "organization": None,
-        "workgroups": [20, 21, 22]
+        "count": 1,
+        "num_pages": 1,
+        "current_page": 1,
+        "results": [
+            {
+                "id": 2,
+                "url": "/api/server/projects/2/",
+                "created": "2015-08-04T13:26:01Z", "modified": "2015-08-04T13:26:01Z",
+                "course_id": "course1",
+                "content_id": "i4x://MyCompany/GP2/gp-v2-project/41fe8cae0614470c9aeb72bd078b0348",
+                "organization": None,
+                "workgroups": [20, 21, 22]
+            }
+        ],
+        "next": None,
+        "start": 0,
+        "previous": None
+    }
+    two_projects = {
+        "count": 2,
+        "num_pages": 1,
+        "current_page": 1,
+        "results": [
+            {
+                "id": 1,
+                "url": "/api/server/projects/1/",
+                "created": None, "modified": None,
+                "course_id": "MyCompany/GP2/T2",
+                "content_id": "i4x://MyCompany/GP2/gp-v2-project/abcdefghijklmnopqrstuvwxyz12345",
+                "organization": "Org1",
+                "workgroups": [1, 2, 3]
+            },
+            {
+                "id": 2,
+                "url": "/api/server/projects/2/",
+                "created": None, "modified": None,
+                "course_id": "MyCompany/GP2/T2",
+                "content_id": "i4x://MyCompany/GP2/gp-v2-project/abcdefghijklmnopqrstuvwxyz12346",
+                "organization": "Org1",
+                "workgroups": [1, 2, 3]
+            }
+
+        ],
+        "next": None,
+        "start": 0,
+        "previous": None
+    }
+    zero_projects = {
+        "count": 0,
+        "num_pages": 1,
+        "current_page": 1,
+        "results": [],
+        "next": None,
+        "start": 0,
+        "previous": None
     }
 
 

--- a/tests/unit/project_api/test_project_api.py
+++ b/tests/unit/project_api/test_project_api.py
@@ -250,8 +250,8 @@ class TestProjectApi(TestCase, TestWithPatchesMixin):
 
     def test_get_project_details(self):
         calls_and_results = {
-            (PROJECTS_API, 1): canned_responses.Projects.project1,
-            (PROJECTS_API, 2): canned_responses.Projects.project2
+            (PROJECTS_API, 1): canned_responses.Projects.project1['results'][0],
+            (PROJECTS_API, 2): canned_responses.Projects.project2['results'][0]
         }
 
         expected_calls = [
@@ -265,8 +265,8 @@ class TestProjectApi(TestCase, TestWithPatchesMixin):
 
             self.assertEqual(patched_send_request.mock_calls, expected_calls)
 
-        self.assert_project_data(project1, canned_responses.Projects.project1)
-        self.assert_project_data(project2, canned_responses.Projects.project2)
+        self.assert_project_data(project1, canned_responses.Projects.project1['results'][0])
+        self.assert_project_data(project2, canned_responses.Projects.project2['results'][0])
 
     @ddt.data(
         ('course1', 'content1'),
@@ -278,24 +278,24 @@ class TestProjectApi(TestCase, TestWithPatchesMixin):
             'course_id': course_id,
             'content_id': content_id
         }
-        calls_and_results = {(PROJECTS_API,): [canned_responses.Projects.project1]}
+        calls_and_results = {(PROJECTS_API,): canned_responses.Projects.project1}
 
         with self._patch_send_request(calls_and_results) as patched_send_request:
             project = self.project_api.get_project_by_content_id(course_id, content_id)
-            self.assert_project_data(project, canned_responses.Projects.project1)
+            self.assert_project_data(project, canned_responses.Projects.project1['results'][0])
 
             patched_send_request.assert_called_once_with(GET, (PROJECTS_API,), query_params=expected_parameters)
 
     def test_get_project_by_content_id_fail_if_more_than_one(self):
         calls_and_results = {
-            (PROJECTS_API,): [canned_responses.Projects.project1, canned_responses.Projects.project2]
+            (PROJECTS_API,): canned_responses.Projects.two_projects
         }
         with self._patch_send_request(calls_and_results), \
                 self.assertRaises(AssertionError):
             self.project_api.get_project_by_content_id('irrelevant', 'irrelevant')
 
     def test_get_project_by_content_id_return_none_if_not_found(self):
-        calls_and_results = {(PROJECTS_API,): []}
+        calls_and_results = {(PROJECTS_API,): canned_responses.Projects.zero_projects}
         with self._patch_send_request(calls_and_results):
             project = self.project_api.get_project_by_content_id('irrelevant', 'irrelevant')
             self.assertIsNone(project)


### PR DESCRIPTION
`dashboard_view` of group project v2 call Projects API to get some of the data needs to be rendered. This API now returns a paginated response having projects info in `results` key
```
{"count":1,"num_pages":1,"current_page":1,"results":[{"id":274,"url":"http://integration.mckinsey.edx.org/api/server/projects/274/","created":"2016-11-12T11:28:15Z","modified":"2016-11-12T11:28:15Z","course_id":"ET1/ET01/2016","content_id":"i4x://ET1/ET01/gp-v2-project/1b4fc43f58a14705bb6c4f0e68f4cbaa","organization":221,"workgroups":[3154,3155,3156,3157,3158,3159]}],"next":null,"start":0,"previous":null}
```
This PR makes these changes to fix admin dashboard of group project. Actual bug with step to reproduce are list [here](https://openedx.atlassian.net/browse/YONK-474)

@bradenmacdonald can some one in you team review this today or tomorrow?
