### PR TITLE
Dependency management update: …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
     - "pip install -r requirements/test.txt"
     - "pip install -r $VIRTUAL_ENV/src/xblock-sdk/requirements/base.txt"
     - "pip install -r $VIRTUAL_ENV/src/xblock-sdk/requirements/test.txt"
-    - "python setup.py sdist && pip install dist/xblock-group-project-v2-0.4.1.tar.gz"
+    - "python setup.py sdist && pip install dist/xblock-group-project-v2-0.4.2.tar.gz"
     - "npm install"
 script:
     - pep8 group_project_v2 tests --max-line-length=120

--- a/group_project_v2/utils.py
+++ b/group_project_v2/utils.py
@@ -84,6 +84,13 @@ def outer_html(node):
 
 def build_date_field(json_date_string_value):
     """ converts json date string to date object """
+    # QUIRK: dateutil behaves slightly differently between 2.1 and 2.6. When empty string is parsed
+    # 2.1 returns beginning of the day, localtime
+    # 2.6 raises value error
+    # THis check is here to make this behavior consistent
+    if not json_date_string_value:
+        return None
+
     try:
         return parser.parse(json_date_string_value)
     except (ValueError, OverflowError):

--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
         "karma-requirejs": ">=0.2.5",
         "karma-jquery": ">=0.1",
         "karma-coverage": ">=0.5",
+        "jasmine-core": ">=2.6.0",
         "jasmine-jquery": ">=2.1",
-        "jshint": ">=2.9"
+        "jshint": ">=2.9",
+        "requirejs": ">=2.1"
     },
     "repository": {
         "type": "git",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,16 @@
--e git+https://github.com/edx/xblock-utils.git@08e5a5a9fc8ab46b627435427fd7e04c20809009#egg=xblock-utils
--e git+https://github.com/mckinseyacademy/django-upload-validator@90c0e31da525336635eb56da98c1355e3f68aba8#egg=django-upload-validator
+Django>=1.8,<2.0
 lazy>=1.1
+python-dateutil>=2.1,<3.0
+WebOb<2.0
+
+# this guy have one major each year and you'd want to migrate ASAP, since it keeps up with all the real world timezone changes
+pytz
+
+# It is known to work well with 0.4 and 1.0, hence version range covers two major versions
+XBlock>=0.4,<2.0
+
+edx-opaque-keys>=0.4.0
+django-upload-validator>=0.1
+
+-e git+https://github.com/edx/xblock-utils.git@v1.0.5#egg=xblock-utils==v1.0.5
+

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,7 +5,6 @@ selenium==2.52.0
 diff-cover
 django-nose==1.4.1
 
--e git+https://github.com/edx/xblock-sdk.git@v0.1.3#egg=xblock_sdk
--e git+https://github.com/edx/opaque-keys.git@1254ed4d615a428591850656f39f26509b86d30a#egg=opaque-keys
--e git://github.com/nosedjango/nosedjango.git@ed7d7f9aa969252ff799ec159f828eaa8c1cbc5a#egg=nosedjango-dev
--e git+https://github.com/edx/edx-notifications.git@8038452f6fbb2b95ad46f8fe7a2f80b145b45b9c#egg=edx-notifications
+-e git+https://github.com/edx/xblock-sdk.git@c40b5dc3e9a2ded54119e922edf486d3ccec6c35#egg=xblock_sdk
+-e git://github.com/nosedjango/nosedjango.git@v1.0.12#egg=nosedjango-dev==v1.0.12
+-e git+https://github.com/edx/edx-notifications.git@0.6.0#egg=edx-notifications==0.6.0

--- a/setup.py
+++ b/setup.py
@@ -24,19 +24,25 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-group-project-v2',
-    version='0.4.1',
+    version='0.4.2',
     description='XBlock - Group Project V2',
     packages=['group_project_v2'],
     install_requires=[
-        'XBlock',
-        'xblock-utils',
-        'django-upload-validator'
+        'Django>=1.8,<2.0',
+        'lazy>=1.1',
+        'python-dateutil>=2.1,<3.0',
+        'WebOb>=1.6,<2.0',
+        'pytz',
+        'XBlock>=0.4,<2.0',
+        'xblock-utils>=0.9',
+        'django-upload-validator>=0.1',
+        'edx-opaque-keys>=0.4'
     ],
     entry_points={
         'xblock.v1': ENTRYPOINTS
     },
     dependency_links = [
-        'https://github.com/mckinseyacademy/django-upload-validator/tarball/b7152b63af6698116337def90a3e6f42ccc06f81#egg=django-upload-validator-0.1.0'
+        'https://github.com/edx/xblock-utils/tarball/v1.0.5#egg=xblock-utils-1.0.5'
     ],
     package_data=package_data("group_project_v2", ["templates", "public"]),
 )


### PR DESCRIPTION
**Description:** Updated versions and listed mandatory dependencies in the setup.py

**Testing instructions:**

1. Rebuild virtualenv from scratch using commands in .travis.yml `install` section
2. Run the tests.
3. Install into edx-platform using local install (i.e. `pip install -e path_to_gpv2_xblock_in_devstack_vm`)
3.1. But first install django-upload-validator (see `requirements/base.txt`)
3.2. Make sure there are no dependency conflicts.
4. Run lms and/or studio
5. Open a course that contains GPv2
6. Make sure it displays ok.

**Merge Checklist:**

- [x] All reviewers approved
- [x] CI build is green
- [x] Commits are (reasonably) squashed

**Post merge:**
- [ ] Update edx-solutions/edx-platform dependency on GPv2