### PR TITLE
Fix packages in setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
     - "pip install -r requirements/test.txt"
     - "pip install -r $VIRTUAL_ENV/src/xblock-sdk/requirements/base.txt"
     - "pip install -r $VIRTUAL_ENV/src/xblock-sdk/requirements/test.txt"
-    - "python setup.py sdist && pip install dist/xblock-group-project-v2-0.4.2.tar.gz"
+    - "python setup.py sdist && pip install dist/xblock-group-project-v2-0.4.3.tar.gz"
     - "npm install"
 script:
     - pep8 group_project_v2 tests --max-line-length=120

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # Imports ###########################################################
 
 import os
-from setuptools import setup
+from setuptools import setup, find_packages
 from group_project_v2.app_config import ENTRYPOINTS
 
 
@@ -24,9 +24,9 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-group-project-v2',
-    version='0.4.2',
+    version='0.4.3',
     description='XBlock - Group Project V2',
-    packages=['group_project_v2'],
+    packages=find_packages(),
     install_requires=[
         'Django>=1.8,<2.0',
         'lazy>=1.1',


### PR DESCRIPTION
When installed via pip (not using `-e`), two modules were missing: `group_project_v2.stage` and `group_project_v2.project_api`

Testing instructions:

1. Create and activate a Python 2.7 virtualenv
1. Run `pip install 'git+https://github.com/edx/xblock-utils.git@v1.0.3#egg=xblock-utils==1.0.3'`
1. Compare the result of

```
pip install 'git+https://github.com/open-craft/xblock-group-project-v2.git@0.4.2#egg=xblock-group-project-v2==0.4.2'
```

with

```
pip install 'git+https://github.com/open-craft/xblock-group-project-v2.git@fix-setup-py#egg=xblock-group-project-v2==0.4.3'
```

The former will be missing the `group_project_v2.stage` and `group_project_v2.project_api` modules, while the latter should correctly install them.