### PR TITLE
MCKIN-6182: fix user profile image url according to updated users api

### DIFF
--- a/group_project_v2/project_api/dtos.py
+++ b/group_project_v2/project_api/dtos.py
@@ -25,7 +25,7 @@ class UserDetails(ReducedUserDetails):
     def __init__(self, **kwargs):
         super(UserDetails, self).__init__(**kwargs)
         self.gender = kwargs.get('gender', None)
-        self.avatar_url = kwargs.get('avatar_url', None)
+        self.profile_image_url = kwargs.get('profile_image', {}).get('image_url_medium', None)
         self.city = kwargs.get('city', None)
         self.country = kwargs.get('country', None)
         self.is_active = kwargs.get('is_active', None)

--- a/group_project_v2/stage_components.py
+++ b/group_project_v2/stage_components.py
@@ -445,7 +445,7 @@ class PeerSelectorXBlock(ReviewSubjectSeletorXBlockBase, UserAwareXBlockMixin):
                 'id': peer.id,
                 'username': peer.username,
                 'user_label': make_user_caption(peer),
-                'avatar_url': peer.avatar_url
+                'profile_image_url': peer.profile_image.image_url_medium if hasattr(peer, 'profile_image') else None
             }
             for peer in self.review_subjects
         ]

--- a/group_project_v2/templates/html/components/peer_selector.html
+++ b/group_project_v2/templates/html/components/peer_selector.html
@@ -18,7 +18,7 @@
           <span class="review_subject_label">{% trans "Teammate" %} {{ forloop.counter }}:</span>
           {{ peer.user_label }}
           <span class="review_evaluating_now">{% trans "Evaluating below" %}</span>
-          <img class="avatar" {% if peer.avatar_url %} src="{{peer.avatar_url }}" {% endif %}/>
+          <img class="avatar" {% if peer.profile_image_url %} src="{{peer.profile_image_url }}" {% endif %}/>
         </li>
         {% endfor %}
       </ul>

--- a/group_project_v2/templates/html/components/project_team.html
+++ b/group_project_v2/templates/html/components/project_team.html
@@ -4,7 +4,7 @@
   {% for team_member in team_members %}
     <div class="group-project-team-member">
       <div class="group-project-team-member-avatar">
-        <img class="avatar" {% if team_member.avatar_url %} src="{{team_member.avatar_url }}" {% endif %}/>
+        <img class="avatar" {% if team_member.profile_image_url %} src="{{team_member.profile_image_url }}" {% endif %}/>
       </div>
       <div class="group-project-team-member-data">
         <div class="group-project-team-member-info">


### PR DESCRIPTION
xblock group project v2 calls users API and expects `avatar_url` for user profile image url while users API has been updated to to return profile_image dictionary which contains urls to different size profile images. 
New Response contains a dict of profile_images:
```
"profile_image": {
        "image_url_full": "https://qa.mckinsey.edx.org/static/images/profiles/default_500.4215dbe8010f.png",
        "image_url_large": "https://qa.mckinsey.edx.org/static/images/profiles/default_500.4215dbe8010f.png",
        "image_url_medium": "https://qa.mckinsey.edx.org/static/images/profiles/default_160.d50822e97e4a.png",
        "image_url_small": "https://qa.mckinsey.edx.org/static/images/profiles/default_48.bcde3c9b8ab8.png",
        "has_image": false
    }
```

This PR updates xblock group project V2 to use that new response.
@bradenmacdonald Please review