### PR TITLE
MCKIN-6282: fix profile image display issue on team evaluation stage

### DIFF
--- a/group_project_v2/stage_components.py
+++ b/group_project_v2/stage_components.py
@@ -445,7 +445,7 @@ class PeerSelectorXBlock(ReviewSubjectSeletorXBlockBase, UserAwareXBlockMixin):
                 'id': peer.id,
                 'username': peer.username,
                 'user_label': make_user_caption(peer),
-                'profile_image_url': peer.profile_image.image_url_medium if hasattr(peer, 'profile_image') else None
+                'profile_image_url': peer.profile_image_url
             }
             for peer in self.review_subjects
         ]


### PR DESCRIPTION
This PR fixes profile image display issue on team evaluation stage page.

Before fix:
![gp_before](https://user-images.githubusercontent.com/3198290/31817329-ec6f9d92-b5ac-11e7-9238-4f6d130757c5.png)

After fix:
![gp_after](https://user-images.githubusercontent.com/3198290/31817338-f41c5a08-b5ac-11e7-82cd-432de3855624.png)


@bradenmacdonald would you please review?