### PR TITLE
Bump version to 0.4.5.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-group-project-v2',
-    version='0.4.4',
+    version='0.4.5',
     description='XBlock - Group Project V2',
     packages=find_packages(),
     install_requires=[


### PR DESCRIPTION
Includes fixes from https://github.com/open-craft/xblock-group-project-v2/pull/116