### PR TITLE
Fix bug with automatic upload of clipboard images

### DIFF
--- a/group_project_v2/public/js/components/submission.js
+++ b/group_project_v2/public/js/components/submission.js
@@ -84,6 +84,7 @@ function GroupProjectSubmissionBlock(runtime, element) {
                 value: $.cookie('csrftoken')
             }
         ],
+        pasteZone: null,
         add: function (e, data) {
             var target_form = $(e.target),
                 parentData = data;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "group_project_xblock_v2",
-    "version": "v0.4.0",
+    "version": "v0.4.9",
     "description": "Group Project XBlock v2",
     "dependencies": {},
     "devDependencies": {

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-group-project-v2',
-    version='0.4.8',
+    version='0.4.9',
     description='XBlock - Group Project V2',
     packages=find_packages(),
     install_requires=[


### PR DESCRIPTION
Fixes bug where pasting rich clipboard data containing both an image and text component can cause the image component to be uploaded as a file when trying to paste the text component in a textbox. 

**JIRA tickets**: MCKIN-7806 / OC-4789