### PR TITLE
Add button in navigator to check all submissions and mark complete

### DIFF
--- a/group_project_v2/project_navigator.py
+++ b/group_project_v2/project_navigator.py
@@ -384,7 +384,7 @@ class SubmissionsViewXBlock(ProjectNavigatorViewXBlockBase):
         return self.render_student_view(context, activity_fragments)
 
     @XBlock.handler
-    def check_submissions(self, request, _suffix=''):
+    def check_submissions(self, _request, _suffix=''):
         new_stage_data = []
         for activity in self.navigator.group_project.activities:
             for stage in activity.stages:
@@ -395,7 +395,6 @@ class SubmissionsViewXBlock(ProjectNavigatorViewXBlockBase):
             "new_stage_data": new_stage_data
         }
         return webob.response.Response(body=json.dumps(results))
-
 
 
 # pylint-disable=no-init

--- a/group_project_v2/project_navigator.py
+++ b/group_project_v2/project_navigator.py
@@ -381,6 +381,14 @@ class SubmissionsViewXBlock(ProjectNavigatorViewXBlockBase):
         context = {'view': self, 'activity_contents': [frag.content for frag in activity_fragments]}
         return self.render_student_view(context, activity_fragments)
 
+    @XBlock.handler
+    def check_submissions(self, request, _suffix=''):
+        for activity in self.navigator.group_project.activities:
+            for stage in activity.stages:
+                if stage.CATEGORY == 'gp-v2-stage-submission':
+                    stage.check_submissions_and_mark_complete()
+
+
 
 # pylint-disable=no-init
 class AskTAViewXBlock(ProjectNavigatorViewXBlockBase):

--- a/group_project_v2/project_navigator.py
+++ b/group_project_v2/project_navigator.py
@@ -3,6 +3,8 @@ This module contains Project Navigator XBlock and it's children view XBlocks
 """
 import logging
 from lazy.lazy import lazy
+import webob
+import json
 from opaque_keys import InvalidKeyError
 from xblock.core import XBlock
 from xblock.exceptions import NoSuchUsage
@@ -383,10 +385,16 @@ class SubmissionsViewXBlock(ProjectNavigatorViewXBlockBase):
 
     @XBlock.handler
     def check_submissions(self, request, _suffix=''):
+        new_stage_data = []
         for activity in self.navigator.group_project.activities:
             for stage in activity.stages:
                 if stage.CATEGORY == 'gp-v2-stage-submission':
                     stage.check_submissions_and_mark_complete()
+                    new_stage_data.append(stage.get_new_stage_state_data())
+        results = {
+            "new_stage_data": new_stage_data
+        }
+        return webob.response.Response(body=json.dumps(results))
 
 
 

--- a/group_project_v2/project_navigator.py
+++ b/group_project_v2/project_navigator.py
@@ -385,16 +385,12 @@ class SubmissionsViewXBlock(ProjectNavigatorViewXBlockBase):
 
     @XBlock.handler
     def check_submissions(self, _request, _suffix=''):
-        new_stage_data = []
         for activity in self.navigator.group_project.activities:
             for stage in activity.stages:
                 if stage.CATEGORY == 'gp-v2-stage-submission':
                     stage.check_submissions_and_mark_complete()
-                    new_stage_data.append(stage.get_new_stage_state_data())
-        results = {
-            "new_stage_data": new_stage_data
-        }
-        return webob.response.Response(body=json.dumps(results))
+        result = {'result': 'ok'}
+        return webob.response.Response(body=json.dumps(result))
 
 
 # pylint-disable=no-init

--- a/group_project_v2/public/css/project_navigator/submissions_view.css
+++ b/group_project_v2/public/css/project_navigator/submissions_view.css
@@ -8,7 +8,7 @@
     border-bottom: none;
 }
 
-.group-project-submissions-view .action_buttons {
+.group-project-submissions-view .action_buttons .cancel_upload {
     /* should not be visible by default, but still consume space to avoid resizing view - hence using visibility, not display*/
     visibility: hidden;
 }

--- a/group_project_v2/public/js/project_navigator/submissions_view.js
+++ b/group_project_v2/public/js/project_navigator/submissions_view.js
@@ -35,7 +35,6 @@ function GroupProjectNavigatorSubmissionsView(runtime, element) {
     });
 
     $(".check_submissions", element).click(function(){
-        alert(runtime.handlerUrl(element, "check_submissions"));
         $.ajax({
             type: "POST",
             url: runtime.handlerUrl(element, "check_submissions"),

--- a/group_project_v2/public/js/project_navigator/submissions_view.js
+++ b/group_project_v2/public/js/project_navigator/submissions_view.js
@@ -2,7 +2,7 @@
 /* exported GroupProjectNavigatorSubmissionsView */
 function GroupProjectNavigatorSubmissionsView(runtime, element) {
     "use strict";
-    var $action_buttons = $(".action_buttons", element);
+    var $cancel_button = $(".cancel_upload", element);
 
     var running_uploads = [];
 
@@ -13,13 +13,13 @@ function GroupProjectNavigatorSubmissionsView(runtime, element) {
         }
 
         if (running_uploads.length === 0) {
-            $action_buttons.css('visibility', 'hidden');
+            $cancel_button.css('visibility', 'hidden');
         }
     }
 
     $(document).on(GroupProjectCommon.Submission.events.upload_started, function(e, uploadXHR){
         running_uploads.push(uploadXHR);
-        $action_buttons.css('visibility', 'visible');
+        $cancel_button.css('visibility', 'visible');
     });
 
     $(document).on(GroupProjectCommon.Submission.events.upload_failed, handle_upload_end);
@@ -31,6 +31,15 @@ function GroupProjectNavigatorSubmissionsView(runtime, element) {
             uploadXHR.abort();
         }
         running_uploads = [];
-        $action_buttons.css('visibility', 'hidden');
+        $cancel_button.css('visibility', 'hidden');
+    });
+
+    $(".check_submissions", element).click(function(){
+        alert(runtime.handlerUrl(element, "check_submissions"));
+        $.ajax({
+            type: "POST",
+            url: runtime.handlerUrl(element, "check_submissions"),
+            data: JSON.stringify({}),
+        });
     });
 }

--- a/group_project_v2/templates/html/project_navigator/submissions_view.html
+++ b/group_project_v2/templates/html/project_navigator/submissions_view.html
@@ -9,5 +9,6 @@
   </div>
   <div class="action_buttons">
     <a href="#" class="cancel_upload">Cancel upload</a>
+    <a href="#" class="check_submissions">Check Submissions</a>
   </div>
 </div>


### PR DESCRIPTION
This PR adds a button to the submission navigator view that will check all submissions and mark them as complete if they're ready.

**Testing instructions**:

1. Comment out `check_submissions_and_mark_complete()` in [group_project_v2/stage_components.py](https://github.com/open-craft/xblock-group-project-v2/blob/master/group_project_v2/stage_components.py#L334)
2. Upload a submission
3. Click the button and see that the submission is marked as complete


**Author notes and concerns**:
It would also be possible to add the button to the [submission navigator view template](https://github.com/open-craft/xblock-group-project-v2/blob/master/group_project_v2/templates/html/components/submission_navigator_view.html). This would simplify finding the function since we wouldn't need the ugly loop over all activities and stages, as the runtime for [the javascript for that block](https://github.com/open-craft/xblock-group-project-v2/blob/master/group_project_v2/public/js/components/submission.js) already associated to a stage, but then there would then be a different button for each stage.

**Reviewers**
- [ ] (@xitij2000)