### PR TITLE
Ensure all block types are excluded from completion.

### DIFF
--- a/group_project_v2/mixins.py
+++ b/group_project_v2/mixins.py
@@ -7,6 +7,7 @@ from lazy.lazy import lazy
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.locator import BlockUsageLocator
 from xblock.fragment import Fragment
+from xblock.completable import XBlockCompletionMode
 from xblockutils.studio_editable import (
     StudioContainerWithNestedXBlocksMixin, StudioContainerXBlockMixin, StudioEditableXBlockMixin
 )
@@ -533,9 +534,14 @@ class TemplateManagerMixin(object):
         return loader.render_template(template_path, context)
 
 
+class CompletionMixin(object):
+    completion_mode = XBlockCompletionMode.EXCLUDED
+
+
 class CommonMixinCollection(
     ChildrenNavigationXBlockMixin, XBlockWithComponentsMixin,
     StudioEditableXBlockMixin, StudioContainerXBlockMixin,
-    WorkgroupAwareXBlockMixin, TemplateManagerMixin, SettingsMixin
+    WorkgroupAwareXBlockMixin, TemplateManagerMixin, SettingsMixin,
+    CompletionMixin,
 ):
     block_settings_key = 'group_project_v2'

--- a/group_project_v2/project_navigator.py
+++ b/group_project_v2/project_navigator.py
@@ -10,16 +10,28 @@ from xblock.fragment import Fragment
 from xblock.validation import ValidationMessage
 
 from xblockutils.studio_editable import (
-    StudioContainerXBlockMixin, StudioEditableXBlockMixin, XBlockWithPreviewMixin, NestedXBlockSpec
+    NestedXBlockSpec,
+    StudioContainerXBlockMixin,
+    StudioEditableXBlockMixin,
+    XBlockWithPreviewMixin,
 )
 
 from group_project_v2 import messages
 from group_project_v2.mixins import (
-    XBlockWithComponentsMixin, ChildrenNavigationXBlockMixin,
-    XBlockWithUrlNameDisplayMixin, AdminAccessControlXBlockMixin, NoStudioEditableSettingsMixin,
+    AdminAccessControlXBlockMixin,
+    ChildrenNavigationXBlockMixin,
+    CompletionMixin,
+    NoStudioEditableSettingsMixin,
+    XBlockWithComponentsMixin,
+    XBlockWithUrlNameDisplayMixin,
 )
 
-from group_project_v2.utils import loader, gettext as _, DiscussionXBlockShim, add_resource
+from group_project_v2.utils import (
+    DiscussionXBlockShim,
+    add_resource,
+    gettext as _,
+    loader,
+)
 
 log = logging.getLogger(__name__)
 
@@ -36,8 +48,13 @@ class ViewTypes(object):
 
 
 class GroupProjectNavigatorXBlock(
-    ChildrenNavigationXBlockMixin, XBlockWithComponentsMixin, XBlockWithPreviewMixin,
-    NoStudioEditableSettingsMixin, StudioContainerXBlockMixin, XBlock
+    ChildrenNavigationXBlockMixin,
+    XBlockWithComponentsMixin,
+    XBlockWithPreviewMixin,
+    NoStudioEditableSettingsMixin,
+    StudioContainerXBlockMixin,
+    CompletionMixin,
+    XBlock
 ):
     """
     XBlock that provides basic layout and switching between children XBlocks (views)
@@ -162,8 +179,12 @@ class GroupProjectNavigatorXBlock(
 
 
 class ProjectNavigatorViewXBlockBase(
-    XBlock, XBlockWithPreviewMixin, StudioEditableXBlockMixin, XBlockWithUrlNameDisplayMixin,
-    AdminAccessControlXBlockMixin
+    CompletionMixin,
+    XBlockWithPreviewMixin,
+    StudioEditableXBlockMixin,
+    XBlockWithUrlNameDisplayMixin,
+    AdminAccessControlXBlockMixin,
+    XBlock,  # Moved from start.  Mixins usually come first.
 ):
     """
     Base class for Project Navigator children XBlocks (views)

--- a/group_project_v2/stage_components.py
+++ b/group_project_v2/stage_components.py
@@ -19,22 +19,35 @@ from xblockutils.studio_editable import StudioEditableXBlockMixin, XBlockWithPre
 from group_project_v2 import messages
 from group_project_v2.api_error import ApiError
 from group_project_v2.mixins import (
-    WorkgroupAwareXBlockMixin, NoStudioEditableSettingsMixin, UserAwareXBlockMixin
+    CompletionMixin,
+    NoStudioEditableSettingsMixin,
+    UserAwareXBlockMixin,
+    WorkgroupAwareXBlockMixin,
 )
 from group_project_v2.project_api import ProjectAPIXBlockMixin
 from group_project_v2.project_navigator import ResourcesViewXBlock, SubmissionsViewXBlock
 from group_project_v2.upload_file import UploadFile
-from group_project_v2.utils import get_link_to_block, FieldValuesContextManager, MUST_BE_OVERRIDDEN, add_resource, \
-    make_user_caption
 from group_project_v2.utils import (
-    outer_html, gettext as _, loader, format_date, build_date_field, mean,
-    groupwork_protected_view
+    FieldValuesContextManager,
+    MUST_BE_OVERRIDDEN,
+    add_resource,
+    get_link_to_block,
+    make_user_caption,
+)
+from group_project_v2.utils import (
+    build_date_field,
+    format_date,
+    gettext as _,
+    groupwork_protected_view,
+    loader,
+    mean,
+    outer_html,
 )
 
 log = logging.getLogger(__name__)
 
 
-class BaseStageComponentXBlock(XBlock):
+class BaseStageComponentXBlock(CompletionMixin, XBlock):
     @lazy
     def stage(self):
         """

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,8 +6,8 @@ WebOb<2.0
 # this guy have one major each year and you'd want to migrate ASAP, since it keeps up with all the real world timezone changes
 pytz
 
-# It is known to work well with 0.4 and 1.0, hence version range covers two major versions
-XBlock>=0.4,<2.0
+#XBlock>=1.2.2,<2.0
+git+https://github.com/edx/XBlock@cliff/completion-get-mode#egg=XBlock==1.2.2a1
 
 edx-opaque-keys>=0.4.0
 django-upload-validator>=0.1

--- a/tests/unit/test_mixins.py
+++ b/tests/unit/test_mixins.py
@@ -1,12 +1,15 @@
 # pylint:disable=protected-access,no-self-use,invalid-name
+
 from unittest import TestCase
 
 import ddt
 import mock
 from opaque_keys.edx.locator import BlockUsageLocator, CourseLocator
+from xblock.completable import XBlockCompletionMode
 from xblock.core import XBlock
 from xblock.runtime import Runtime
 
+from group_project_v2 import app_config
 from group_project_v2.mixins import (
     ChildrenNavigationXBlockMixin, CourseAwareXBlockMixin, UserAwareXBlockMixin,
     WorkgroupAwareXBlockMixin, DashboardRootXBlockMixin,
@@ -46,6 +49,19 @@ class ChildrenNavigationXBlockMixinGuineaPig(ChildrenNavigationXBlockMixin, Comm
     @property
     def children(self):
         return None
+
+
+@ddt.ddt
+class CompletionMixinTestCase(TestCase):
+
+    @ddt.data(*app_config.PROGRESS_DETACHED_CATEGORIES)
+    def test_all_blocks_excluded_from_completion(self, blockclass):
+        xblock = XBlock.load_class(blockclass)
+        self.assertEqual(
+            XBlockCompletionMode.get_mode(xblock),
+            XBlockCompletionMode.EXCLUDED,
+            "Block {!r} did not have completion mode 'excluded'".format(xblock),
+        )
 
 
 class TestChildrenNavigationXBlockMixin(TestWithPatchesMixin, TestCase):


### PR DESCRIPTION
Resolves [OC-5161](https://tasks.opencraft.com/browse/OC-5161) 

All group project blocks should be excluded from completion, as described in the ticket.

## Author notes

* The tests use a new method on XBlock, so there's an added PR over there.  Before merging, the requirement should be updated to use a tagged release of XBlock.  If that takes too long to merge, the tests here can be altered to manually calculate the completion_mode. (edx/XBlock#385)
* I tried to spend a little time making this xblock python-3 compatible before starting work on this ticket.  That work  was blocked by incompatibility in https://github.com/edx/edx-notifications, which proved too difficult to update simply (lots of manual checking for str vs unicode).  The work on making group_project_v2 python3 compatible is incomplete, but in a mergeable state in a related PR (https://github.com/open-craft/xblock-group-project-v2/pull/123), and this work is built on top of it.

## Reviewers

- [ ] @xitij2000 

