### PR TITLE
MCKIN-8797: Bump required xblock versions.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,8 +6,7 @@ WebOb<2.0
 # this guy have one major each year and you'd want to migrate ASAP, since it keeps up with all the real world timezone changes
 pytz
 
-#XBlock>=1.2.2,<2.0
-git+https://github.com/edx/XBlock@cliff/completion-get-mode#egg=XBlock==1.2.2a1
+XBlock>=1.2.2,<2.0
 
 edx-opaque-keys>=0.4.0
 django-upload-validator>=0.1

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         'python-dateutil>=2.1,<3.0',
         'WebOb>=1.6,<2.0',
         'pytz',
-        'XBlock>=0.4,<2.0',
+        'XBlock>=1.2.2,<2.0',
         'xblock-utils>=0.9',
         'django-upload-validator>=0.1',
         'edx-opaque-keys>=0.4'

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-group-project-v2',
-    version='0.4.9',
+    version='0.4.11',
     description='XBlock - Group Project V2',
     packages=find_packages(),
     install_requires=[


### PR DESCRIPTION
@xitij2000 Here's the version bump.  Note that the current build should be fine, because the xblock version is defined as >0.4,<2.0 in the setup.py, which is where it matters when it gets pip installed.