### PR TITLE
YONK-1306: Hotfix setup.py issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         'pytz',
         'XBlock>=1.2.2,<2.0',
         'xblock-utils>=0.9',
+        'django-upload-validator==1.0.2',
         'edx-opaque-keys>=0.4'
     ],
     entry_points={
@@ -42,7 +43,7 @@ setup(
     },
     dependency_links = [
         'https://github.com/edx/xblock-utils/tarball/v1.0.5#egg=xblock-utils-1.0.5',
-        'https://github.com/mckinseyacademy/django-upload-validator/tarball/v1.0.2#egg=django-upload-validator==v1.0.2'
+        'https://github.com/mckinseyacademy/django-upload-validator/tarball/v1.0.2#egg=django-upload-validator-1.0.2'
     ],
     package_data=package_data("group_project_v2", ["templates", "public"]),
 )

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-group-project-v2',
-    version='0.4.12',
+    version='0.4.13',
     description='XBlock - Group Project V2',
     packages=find_packages(),
     install_requires=[


### PR DESCRIPTION
https://github.com/open-craft/xblock-group-project-v2/pull/126 was merged with a issue that only was perceived while the CI on edx-platform was run. The dependency links on `setup.py` file need to have a specific name to work, e.g. `#egg=django-upload-validator-1.0.2` (`package_name-version`).

This PR fixes that typo.

**Testing instructions:**
1. Clone this branch.
2. On a python 2.7 venv, run `pip install -e . --process-dependency-links` and check that the setup is completed successfully.

**Reviewers:**
- [ ] @Agrendalath 
