### PR TITLE
MCKIN-11136-django-storage-downgrade

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 boto>=2.1.0
 boto3==1.9.173
 Django>=1.8,<2.0
-django-storages==1.6.6
+django-storages==1.4.1
 google-compute-engine==2.8.13
 lazy>=1.1
 python-dateutil>=2.1,<3.0

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-group-project-v2',
-    version='0.5',
+    version='0.5.1',
     description='XBlock - Group Project V2',
     packages=find_packages(),
     install_requires=[
@@ -40,7 +40,7 @@ setup(
         'boto>=2.1.0',
         'boto3==1.9.173',
         'google-compute-engine==2.8.13',
-        'django-storages==1.6.6'
+        'django-storages==1.4.1'
     ],
     entry_points={
         'xblock.v1': ENTRYPOINTS


### PR DESCRIPTION
Downgrading Django storage to 1.4.1 because it is failing tests on edx platform