### PR TITLE
MCKIN-12639: downgrade boto3 to 1.4.8 to fix conflict with ironwood

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 boto>=2.1.0
-boto3==1.9.173
+boto3==1.4.8
 Django>=1.8,<2.0
 django-storages==1.4.1
 google-compute-engine==2.8.13

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-group-project-v2',
-    version='0.5.1',
+    version='0.6.0',
     description='XBlock - Group Project V2',
     packages=find_packages(),
     install_requires=[
@@ -38,7 +38,7 @@ setup(
         'django-upload-validator==1.0.2',
         'edx-opaque-keys>=0.4',
         'boto>=2.1.0',
-        'boto3==1.9.173',
+        'boto3==1.4.8',
         'google-compute-engine==2.8.13',
         'django-storages==1.4.1'
     ],


### PR DESCRIPTION
Issue: Boto3 was not being used in edx-platform before ironwood release but it has been added in ironwood now. Ironwood is using `boto3==1.4.8` and this library is also being used in xblock-group-project-v2. In Xblock the boto3 version is 1.9.173 which is resulting in version conflict with edx-platform.

This PR downgrades `boto3` version to `1.4.8` for `xblock-group-project-v2` to make it compatible with `ironwood` release of `edx-platform`.