### PR TITLE
MCKIN-12706: Support for Brightcove video resource playback

### DIFF
--- a/group_project_v2/public/js/project_navigator/resources_view.js
+++ b/group_project_v2/public/js/project_navigator/resources_view.js
@@ -1,4 +1,5 @@
 /* global OO */
+/* global videojs */
 /* exported GroupProjectNavigatorResourcesView */
 function GroupProjectNavigatorResourcesView(runtime, element) {
     "use strict";
@@ -31,8 +32,9 @@ function GroupProjectNavigatorResourcesView(runtime, element) {
             });
             showPlayer();
         }else if(playerType === 'ooyala'){
-            if (typeof OO === 'undefined') 
+            if (typeof OO === 'undefined'){ 
                 return;
+            }
         
             player.append($('<div id="'+ooyala_player_target_element_id+'"/>'));
             var parameters = {width: '100%', height: '100%', autoplay: true};

--- a/group_project_v2/public/js/project_navigator/resources_view.js
+++ b/group_project_v2/public/js/project_navigator/resources_view.js
@@ -20,29 +20,50 @@ function GroupProjectNavigatorResourcesView(runtime, element) {
 
     $('a[data-video-id]', element).on('click', function (e) {
         e.preventDefault();
-        var video = $(e.currentTarget).data('video-id');
-
-        player.append($('<div id="'+ooyala_player_target_element_id+'"/>'));
-
-        if (typeof OO === 'undefined') {
+        var videoId = $(e.currentTarget).data('video-id');
+        var playerType = $(e.currentTarget).data('player-type');
+        
+        // kickoff player according to video type
+        if (playerType === 'brightcove'){
+            var elemId = $('.video-js').attr('id');
+            videojs.getPlayer(elemId).ready(function () {
+                this.play();
+            });
+            showPlayer();
+        }else if(playerType === 'ooyala'){
+            if (typeof OO === 'undefined') 
+                return;
+        
+            player.append($('<div id="'+ooyala_player_target_element_id+'"/>'));
+            var parameters = {width: '100%', height: '100%', autoplay: true};
+            var video = OO.Player.create(ooyala_player_target_element_id, videoId, parameters);
+            modal.data('video', video);
+            showPlayer();
+        }else{
             return;
         }
-        // TODO: manually using ooyala - replace with Ooyala player XBlock when it's autostart setting is fixed
-        // and play-stop-destroy events are exposed.
-        var parameters = {width: '100%', height: '100%', autoplay: true};
-
-        var  ooyala = OO.Player.create(ooyala_player_target_element_id, video, parameters);
-        modal.data('ooyala', ooyala);
-        showPlayer();
     });
 
     $('.close-reveal-modal', element).add('.player-modal-bg', element).on('click', function () {
-        var ooyala = modal.data('ooyala');
-        if (ooyala) {
-            ooyala.destroy();
-            modal.removeData('ooyala');
+        var video = modal.data('video');
+        var bcVideo = $('.video-js', modal);
+
+        if (video) {
+            video.destroy();
+            player.empty();
+            modal.removeData('video');
         }
-        player.empty();
+
+        // stop any BC video 
+        if(bcVideo.length){
+            videojs.getPlayer(bcVideo.attr('id')).ready(function () {
+                this.pause();
+                // seek to zero as no stop method is available 
+                // in HTML5 video API
+                this.currentTime(0);
+            });
+        }
+        
         hidePlayer();
     });
 }

--- a/group_project_v2/stage_components.py
+++ b/group_project_v2/stage_components.py
@@ -112,10 +112,11 @@ class GroupProjectVideoResourceXBlock(BaseGroupProjectResourceXBlock):
     CATEGORY = "gp-v2-video-resource"
     STUDIO_LABEL = _(u"Video Resource")
     PROJECT_NAVIGATOR_VIEW_TEMPLATE = 'templates/html/components/video_resource.html'
+    BRIGHTCOVE_ACCOUNT_ID = '6057949416001'
 
     video_id = String(
-        display_name=_(u"Ooyala content ID"),
-        help=_(u"This is the Ooyala Content Identifier"),
+        display_name=_(u"Ooyala/Brightcove content ID"),
+        help=_(u"This is the Ooyala/Brightcove Content Identifier"),
         default="Q1eXg5NzpKqUUzBm5WTIb6bXuiWHrRMi",
         scope=Scope.content,
     )
@@ -126,10 +127,28 @@ class GroupProjectVideoResourceXBlock(BaseGroupProjectResourceXBlock):
     def is_available(cls):
         return True  # TODO: restore conditional availability when switched to use actual Ooyala XBlock
 
+    @property
+    def video_type(self):
+        """
+        Checks if video_id belongs to Brightcove or Ooyala
+        """
+        try:
+            # Brightcove IDs are numeric
+            int(self.video_id)
+            return 'brightcove'
+        except (ValueError, TypeError):
+            return 'ooyala'
+
     def resources_view(self, context):
-        render_context = {'video_id': self.video_id}
+        render_context = {
+            'video_id': self.video_id,
+            'player_type': self.video_type,
+            'bc_account_id': self.BRIGHTCOVE_ACCOUNT_ID,
+        }
         render_context.update(context)
         fragment = super(GroupProjectVideoResourceXBlock, self).resources_view(render_context)
+        fragment.add_javascript_url(url='//players.brightcove.net/{}/default_default/index.min.js'
+                                .format(self.BRIGHTCOVE_ACCOUNT_ID))
         return fragment
 
     def author_view(self, context):

--- a/group_project_v2/stage_components.py
+++ b/group_project_v2/stage_components.py
@@ -148,7 +148,7 @@ class GroupProjectVideoResourceXBlock(BaseGroupProjectResourceXBlock):
         render_context.update(context)
         fragment = super(GroupProjectVideoResourceXBlock, self).resources_view(render_context)
         fragment.add_javascript_url(url='//players.brightcove.net/{}/default_default/index.min.js'
-                                .format(self.BRIGHTCOVE_ACCOUNT_ID))
+                                    .format(self.BRIGHTCOVE_ACCOUNT_ID))
         return fragment
 
     def author_view(self, context):

--- a/group_project_v2/stage_components.py
+++ b/group_project_v2/stage_components.py
@@ -127,8 +127,8 @@ class GroupProjectVideoResourceXBlock(BaseGroupProjectResourceXBlock):
     def is_available(cls):
         return True  # TODO: restore conditional availability when switched to use actual Ooyala XBlock
 
-    @property
-    def brightcove_account_id(self):
+    @classmethod
+    def brightcove_account_id(cls):
         """
         Gets bcove account id from settings
         """
@@ -151,12 +151,12 @@ class GroupProjectVideoResourceXBlock(BaseGroupProjectResourceXBlock):
         render_context = {
             'video_id': self.video_id,
             'player_type': self.video_type,
-            'bc_account_id': self.brightcove_account_id,
+            'bc_account_id': self.brightcove_account_id(),
         }
         render_context.update(context)
         fragment = super(GroupProjectVideoResourceXBlock, self).resources_view(render_context)
         fragment.add_javascript_url(url='//players.brightcove.net/{}/default_default/index.min.js'
-                                    .format(self.brightcove_account_id))
+                                    .format(self.brightcove_account_id()))
         return fragment
 
     def author_view(self, context):

--- a/group_project_v2/stage_components.py
+++ b/group_project_v2/stage_components.py
@@ -7,6 +7,7 @@ import webob
 from datetime import date
 
 from django.core.exceptions import ValidationError
+from django.conf import settings
 from django.utils import html
 from lazy.lazy import lazy
 from upload_validator import FileTypeValidator
@@ -112,7 +113,6 @@ class GroupProjectVideoResourceXBlock(BaseGroupProjectResourceXBlock):
     CATEGORY = "gp-v2-video-resource"
     STUDIO_LABEL = _(u"Video Resource")
     PROJECT_NAVIGATOR_VIEW_TEMPLATE = 'templates/html/components/video_resource.html'
-    BRIGHTCOVE_ACCOUNT_ID = '6057949416001'
 
     video_id = String(
         display_name=_(u"Ooyala/Brightcove content ID"),
@@ -126,6 +126,14 @@ class GroupProjectVideoResourceXBlock(BaseGroupProjectResourceXBlock):
     @classmethod
     def is_available(cls):
         return True  # TODO: restore conditional availability when switched to use actual Ooyala XBlock
+
+    @property
+    def brightcove_account_id(self):
+        """
+        Gets bcove account id from settings
+        """
+        xblock_settings = settings.XBLOCK_SETTINGS if hasattr(settings, "XBLOCK_SETTINGS") else {}
+        return xblock_settings.get('OoyalaPlayerBlock', {}).get('BCOVE_ACCOUNT_ID')
 
     @property
     def video_type(self):
@@ -143,12 +151,12 @@ class GroupProjectVideoResourceXBlock(BaseGroupProjectResourceXBlock):
         render_context = {
             'video_id': self.video_id,
             'player_type': self.video_type,
-            'bc_account_id': self.BRIGHTCOVE_ACCOUNT_ID,
+            'bc_account_id': self.brightcove_account_id,
         }
         render_context.update(context)
         fragment = super(GroupProjectVideoResourceXBlock, self).resources_view(render_context)
         fragment.add_javascript_url(url='//players.brightcove.net/{}/default_default/index.min.js'
-                                    .format(self.BRIGHTCOVE_ACCOUNT_ID))
+                                    .format(self.brightcove_account_id))
         return fragment
 
     def author_view(self, context):

--- a/group_project_v2/templates/html/components/video_resource.html
+++ b/group_project_v2/templates/html/components/video_resource.html
@@ -1,3 +1,29 @@
 <div class="resource_link">
-  <a href="#" class="group-project-video-resource" data-video-id="{{ video_id }}">{{ resource.display_name }}</a>{% if resource.description %}: {{ resource.description }}{% endif %}
+  <a
+    href="#"
+    class="group-project-video-resource"
+    data-player-type="{{ player_type }}"
+    data-video-id="{{ video_id }}">
+    {{ resource.display_name }}
+  </a>{% if resource.description %}: {{ resource.description }}{% endif %}
 </div>
+<div class="player-modal reveal-modal medium">
+    <div class="close-reveal-modal">
+      <span class="fa fa-times-circle"></span>
+    </div>
+    <div class="player-wrapper">
+      {% if player_type == 'brightcove' %}
+      <video-js
+          id="video-resource-{{ video_id }}"
+          data-account="{{ bc_account_id }}"
+          data-video-id="{{ video_id }}"
+          data-player="default"
+          data-embed="default"
+          controls=""
+          playsinline=""
+          width="360px" height="200px">
+      </video-js>
+      {% endif %}
+    </div>
+</div>
+<div class="player-modal-bg"></div>

--- a/group_project_v2/templates/html/components/video_resource.html
+++ b/group_project_v2/templates/html/components/video_resource.html
@@ -20,7 +20,6 @@
           data-player="default"
           data-embed="default"
           controls=""
-          playsinline=""
           width="360px" height="200px">
       </video-js>
       {% endif %}

--- a/group_project_v2/templates/html/project_navigator/resources_view.html
+++ b/group_project_v2/templates/html/project_navigator/resources_view.html
@@ -7,12 +7,4 @@
   <div class="group-project-navigator-view-content">
     {% for activity_content in activity_contents %}{{ activity_content|safe }}{% endfor %}
   </div>
-
-  <div class="player-modal reveal-modal medium">
-    <div class="close-reveal-modal">
-      <span class="fa fa-times-circle"></span>
-    </div>
-    <div class="player-wrapper"></div>
-  </div>
-  <div class="player-modal-bg"></div>
 </div>


### PR DESCRIPTION
This PR adds support for Brightcove video playback in GW GroupProjectVideoResourceXBlock. Currently only Ooyala video is supported.

**Testing Instructions:**

1. Install this branch in devstack. Author a `Group Project V2` unit in a course from Studio. 
2. Add a `Group Project Activity` component in it.
3. Add a `Completion Stage` component in Group Project Activity.
4. Add a `Video Resource` 
<img width="903" alt="Screen Shot 2019-12-17 at 2 01 10 PM" src="https://user-images.githubusercontent.com/6681794/70980823-c268ea80-20d5-11ea-99ef-570ae02cd356.png">

5. Make sure both Ooyala and Brightcove videos play fine when rendered on Apros

Sample BC video: `6068614553001`
Sample Ooyala video: `80Z21uNzE6nDAecFlIaDYCweyWk75Kap`

 

