### PR TITLE
playsinline attribute added to support inline video play

### DIFF
--- a/group_project_v2/templates/html/components/video_resource.html
+++ b/group_project_v2/templates/html/components/video_resource.html
@@ -20,6 +20,7 @@
           data-player="default"
           data-embed="default"
           controls=""
+          playsinline=""
           width="360px" height="200px">
       </video-js>
       {% endif %}

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-group-project-v2',
-    version='0.7.0',
+    version='0.7.1',
     description='XBlock - Group Project V2',
     packages=find_packages(),
     install_requires=[


### PR DESCRIPTION
`playsinline` attribute added in Brightcove embed template to support inline video play