### PR TITLE
Update deprecated xblock.fragment to web_fragments.fragment

### DIFF
--- a/group_project_v2/group_project.py
+++ b/group_project_v2/group_project.py
@@ -10,7 +10,7 @@ from opaque_keys import InvalidKeyError
 from xblock.core import XBlock
 from xblock.exceptions import NoSuchUsage
 from xblock.fields import Scope, String, Float, Integer, DateTime
-from xblock.fragment import Fragment
+from web_fragments.fragment import Fragment
 from xblock.validation import ValidationMessage
 from xblockutils.studio_editable import XBlockWithPreviewMixin, NestedXBlockSpec
 
@@ -139,7 +139,7 @@ class GroupProjectXBlock(CommonMixinCollection, DashboardXBlockMixin, DashboardR
             child_fragment = self._render_child_fragment_with_fallback(
                 child, internal_context, fallback_message, 'student_view'
             )
-            fragment.add_frag_resources(child_fragment)
+            fragment.add_fragment_resources(child_fragment)
             render_context[content_key] = child_fragment.content
 
         target_block_id = self.get_block_id_from_string(ctx.get(Constants.ACTIVATE_BLOCK_ID_PARAMETER_NAME, None))
@@ -218,7 +218,7 @@ class GroupProjectXBlock(CommonMixinCollection, DashboardXBlockMixin, DashboardR
             target_activity, ctx, messages.NO_ACTIVITIES, view='dashboard_detail_view'
         )
         render_context['activity_content'] = activity_fragment.content
-        fragment.add_frag_resources(activity_fragment)
+        fragment.add_fragment_resources(activity_fragment)
 
         fragment.add_content(self.render_template('dashboard_detail_view', render_context))
         add_resource(self, 'css', 'public/css/group_project_common.css', fragment)
@@ -501,7 +501,7 @@ class GroupActivityXBlock(
             fragment.add_content(messages.NO_STAGES)
         else:
             stage_fragment = target_stage.render('student_view', context)
-            fragment.add_frag_resources(stage_fragment)
+            fragment.add_fragment_resources(stage_fragment)
             render_context = {
                 'activity': self,
                 'stage_content': stage_fragment.content,
@@ -598,7 +598,7 @@ class GroupActivityXBlock(
             if not stage.shown_on_detail_view:
                 continue
             stage_fragment = stage.render('dashboard_detail_view', children_context)
-            stage_fragment.add_frag_resources(fragment)
+            stage_fragment.add_fragment_resources(fragment)
             stages.append({"id": stage.id, 'content': stage_fragment.content})
             stage_stats[stage.id] = self._get_stage_completion_details(stage, target_workgroups, target_users)
 

--- a/group_project_v2/group_project.py
+++ b/group_project_v2/group_project.py
@@ -184,7 +184,8 @@ class GroupProjectXBlock(CommonMixinCollection, DashboardXBlockMixin, DashboardR
 
         activity_fragments = self._render_children('dashboard_view', children_context, self.activities)
         activity_contents = [frag.content for frag in activity_fragments]
-        fragment.add_frags_resources(activity_fragments)
+        for activity_fragment in activity_fragments:
+            fragment.add_fragment_resources(activity_fragment)
 
         render_context = {'project': self, 'activity_contents': activity_contents}
         fragment.add_content(self.render_template('dashboard_view', render_context))
@@ -520,7 +521,8 @@ class GroupActivityXBlock(
 
         stage_fragments = self._render_children('navigation_view', children_context, self.available_stages)
         stage_contents = [frag.content for frag in stage_fragments]
-        fragment.add_frags_resources(stage_fragments)
+        for stage_fragment in stage_fragments:
+            fragment.add_fragment_resources(stage_fragment)
 
         render_context = {'activity': self, 'stage_contents': stage_contents}
         fragment.add_content(self.render_template('navigation_view', render_context))
@@ -536,7 +538,8 @@ class GroupActivityXBlock(
 
         resource_fragments = self._render_children('resources_view', context, resources)
         resource_contents = [frag.content for frag in resource_fragments]
-        fragment.add_frags_resources(resource_fragments)
+        for resource_fragment in resource_fragments:
+            fragment.add_fragment_resources(resource_fragment)
 
         render_context = {'activity': self, 'resource_contents': resource_contents, 'has_resources': has_resources}
         fragment.add_content(self.render_template('resources_view', render_context))
@@ -556,7 +559,8 @@ class GroupActivityXBlock(
 
         submission_fragments = self._render_children('submissions_view', context, submissions)
         submission_contents = [frag.content for frag in submission_fragments]
-        fragment.add_frags_resources(submission_fragments)
+        for submission_fragment in submission_fragments:
+            fragment.add_fragment_resources(submission_fragment)
 
         render_context = {
             'activity': self, 'submission_contents': submission_contents, 'has_submissions': has_submissions
@@ -574,7 +578,8 @@ class GroupActivityXBlock(
 
         stage_fragments = self._render_children('dashboard_view', children_context, self.stages)
         stage_contents = [frag.content for frag in stage_fragments]
-        fragment.add_frags_resources(stage_fragments)
+        for stage_fragment in stage_fragments:
+            fragment.add_fragment_resources(stage_fragment)
 
         render_context = {'activity': self, 'stage_contents': stage_contents}
         fragment.add_content(self.render_template('dashboard_view', render_context))

--- a/group_project_v2/mixins.py
+++ b/group_project_v2/mixins.py
@@ -6,7 +6,7 @@ import itertools
 from lazy.lazy import lazy
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.locator import BlockUsageLocator
-from xblock.fragment import Fragment
+from web_fragments.fragment import Fragment
 from xblock.completable import XBlockCompletionMode
 from xblockutils.studio_editable import (
     StudioContainerWithNestedXBlocksMixin, StudioContainerXBlockMixin, StudioEditableXBlockMixin

--- a/group_project_v2/project_navigator.py
+++ b/group_project_v2/project_navigator.py
@@ -6,7 +6,7 @@ from lazy.lazy import lazy
 from opaque_keys import InvalidKeyError
 from xblock.core import XBlock
 from xblock.exceptions import NoSuchUsage
-from xblock.fragment import Fragment
+from web_fragments.fragment import Fragment
 from xblock.validation import ValidationMessage
 
 from xblockutils.studio_editable import (
@@ -123,14 +123,14 @@ class GroupProjectNavigatorXBlock(
             if not view.skip_content:
                 child_fragment = view.render('student_view', context)
                 item['content'] = child_fragment.content
-                fragment.add_frag_resources(child_fragment)
+                fragment.add_fragment_resources(child_fragment)
             else:
                 item['content'] = ''
 
             if not view.skip_selector:
                 child_selector_fragment = view.render('selector_view', context)
                 item['selector'] = child_selector_fragment.content
-                fragment.add_frag_resources(child_selector_fragment)
+                fragment.add_fragment_resources(child_selector_fragment)
             else:
                 item['selector'] = ''
 
@@ -159,7 +159,7 @@ class GroupProjectNavigatorXBlock(
         children_contents = []
         for child in self._children:
             child_fragment = child.render('preview_view', context)
-            fragment.add_frag_resources(child_fragment)
+            fragment.add_fragment_resources(child_fragment)
             children_contents.append(child_fragment.content)
 
         fragment.add_content(loader.render_template(
@@ -263,7 +263,7 @@ class ProjectNavigatorViewXBlockBase(
 
         if add_resources_from:
             for frag in add_resources_from:
-                fragment.add_frag_resources(frag)
+                fragment.add_fragment_resources(frag)
 
         return fragment
 
@@ -274,7 +274,7 @@ class ProjectNavigatorViewXBlockBase(
         fragment = Fragment(self.display_name_with_default)
         url_name_fragment = self.get_url_name_fragment(self.url_name_caption)
         fragment.add_content(url_name_fragment.content)
-        fragment.add_frag_resources(url_name_fragment)
+        fragment.add_fragment_resources(url_name_fragment)
         return fragment
 
     def selector_view(self, _context):

--- a/group_project_v2/stage/base.py
+++ b/group_project_v2/stage/base.py
@@ -6,7 +6,7 @@ from lazy.lazy import lazy
 import pytz
 from xblock.core import XBlock
 from xblock.fields import DateTime, Scope, Boolean
-from xblock.fragment import Fragment
+from web_fragments.fragment import Fragment
 from xblockutils.studio_editable import XBlockWithPreviewMixin
 
 from group_project_v2 import messages
@@ -213,7 +213,7 @@ class BaseGroupActivityStage(
         stage_fragment = self.get_stage_content_fragment(context, view)
 
         fragment = Fragment()
-        fragment.add_frag_resources(stage_fragment)
+        fragment.add_fragment_resources(stage_fragment)
         render_context = {
             'stage': self, 'stage_content': stage_fragment.content,
             "ta_graded": self.activity.group_reviews_required_count
@@ -234,7 +234,7 @@ class BaseGroupActivityStage(
         fragment = self._view_render(context, "preview_view")
         url_name_fragment = self.get_url_name_fragment(self.url_name_caption)
         fragment.add_content(url_name_fragment.content)
-        fragment.add_frag_resources(url_name_fragment)
+        fragment.add_fragment_resources(url_name_fragment)
         return fragment
 
     @groupwork_protected_view
@@ -242,7 +242,7 @@ class BaseGroupActivityStage(
         fragment = super(BaseGroupActivityStage, self).author_edit_view(context)
         url_name_fragment = self.get_url_name_fragment(self.url_name_caption)
         fragment.add_content(url_name_fragment.content)
-        fragment.add_frag_resources(url_name_fragment)
+        fragment.add_fragment_resources(url_name_fragment)
         return fragment
 
     def render_children_fragments(self, context, view='student_view'):
@@ -262,7 +262,7 @@ class BaseGroupActivityStage(
         }
 
         for frag in children_fragments:
-            fragment.add_frag_resources(frag)
+            fragment.add_fragment_resources(frag)
 
         render_context.update(context)
         fragment.add_content(loader.render_template(self.STAGE_CONTENT_TEMPLATE, render_context))

--- a/group_project_v2/stage/basic.py
+++ b/group_project_v2/stage/basic.py
@@ -1,7 +1,7 @@
 import logging
 from xblock.core import XBlock
 from xblock.fields import String, Scope
-from xblock.fragment import Fragment
+from web_fragments.fragment import Fragment
 from xblock.validation import ValidationMessage
 
 from group_project_v2 import messages
@@ -183,7 +183,7 @@ class SubmissionStage(BaseGroupActivityStage):
         submission_contents = []
         for submission in self.submissions:
             submission_fragment = submission.render(child_view, context)
-            fragment.add_frag_resources(submission_fragment)
+            fragment.add_fragment_resources(submission_fragment)
             submission_contents.append(submission_fragment.content)
 
         context = {'stage': self, 'submission_contents': submission_contents}

--- a/group_project_v2/stage_components.py
+++ b/group_project_v2/stage_components.py
@@ -13,7 +13,7 @@ from lazy.lazy import lazy
 from upload_validator import FileTypeValidator
 from xblock.core import XBlock
 from xblock.fields import String, Boolean, Scope, UNIQUE_ID
-from xblock.fragment import Fragment
+from web_fragments.fragment import Fragment
 from xblock.validation import ValidationMessage
 from xblockutils.studio_editable import StudioEditableXBlockMixin, XBlockWithPreviewMixin
 

--- a/group_project_v2/utils.py
+++ b/group_project_v2/utils.py
@@ -16,7 +16,7 @@ from django.utils.safestring import mark_safe
 from django.core.files.storage import default_storage
 from lazy.lazy import lazy
 from storages.backends.s3boto import S3BotoStorage
-from xblock.fragment import Fragment
+from web_fragments.fragment import Fragment
 from xblockutils.resources import ResourceLoader
 
 DEFAULT_EXPIRATION_TIME = timedelta(seconds=10)

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-group-project-v2',
-    version='0.7.1',
+    version='0.7.2',
     description='XBlock - Group Project V2',
     packages=find_packages(),
     install_requires=[


### PR DESCRIPTION
Description
------------

This PR replaces usage of the deprecated `xblock.fragment.Fragment` with `web_fragments.fragment.Fragment`

This also requires changes to method used to load resources from fragments.

Testing
--------
1. Make sure to have a course containing group work present, import the sample one if necessary:

    ```(venv) edxapp@vagrant:~/edx-platform$ ./manage.py cms import /edx/var/edxapp/data/ $(pwd)/xblock-group-project-v2/examples/T1/```

1. Ensure loading the Group Work dashboardV2 works correctly.