### PR TITLE
MCKIN-22507 Exposed API errors to response for tracking

### DIFF
--- a/group_project_v2/stage/review.py
+++ b/group_project_v2/stage/review.py
@@ -183,7 +183,11 @@ class ReviewBaseStage(BaseGroupActivityStage):
                 self.mark_complete()
         except ApiError as exception:
             log.exception(exception.message)
-            return {'result': 'error', 'msg': exception.message}
+            return {
+                'result': 'error',
+                'msg': exception.message,
+                'error': exception.content_dictionary
+            }
 
         return {
             'result': 'success',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-group-project-v2',
-    version='0.8.0',
+    version='0.8.1',
     description='XBlock - Group Project V2',
     packages=find_packages(),
     install_requires=[


### PR DESCRIPTION
Right now submit view is returning `{result': 'error', 'msg': 'Bad Request'}` and it doesn't expose any information's which makes it hard to debug in case of bulk upload. 
AC: Update the endpoint to return the original error i.e. thrown by Projects API, so that we can show the exact error against feedback uploaded for each group(in case if there are any.)