### PR TITLE
[YONK-1748] [BB-2920] Suppress the logs produce in group project when accessed through studio

### DIFF
--- a/group_project_v2/mixins.py
+++ b/group_project_v2/mixins.py
@@ -96,7 +96,9 @@ class UserAwareXBlockMixin(ProjectAPIXBlockMixin):
         try:
             return int(self.real_user_id(self.anonymous_student_id))
         except Exception as exc:
-            log.exception(exc)
+            # Suppressing logs when access through studio
+            if not getattr(self.runtime, 'is_author_mode', False):
+                log.exception(exc)
             try:
                 return int(self.runtime.user_id)
             except Exception as exc:

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-group-project-v2',
-    version='0.9.0',
+    version='0.9.1',
     description='XBlock - Group Project V2',
     packages=find_packages(),
     install_requires=[


### PR DESCRIPTION
This helps to suppress the logs produce in group project when accessed through studio.
Since in studio real_user is not available and this gives us unnecessary logs.

**JIRA tickets**: [BB-2920](https://tasks.opencraft.com/browse/BB-2920)

~~**Sandbox URL**: TBD - sandbox is being provisioned.~~


**Testing instructions**:

1. Get the ironwood box working with edx-solutions/edx-platform code
2. Check-in  `edx-platform` that it is on the development branch
3. Make sure to have created a user or a super-user to test you can do it by running `python manage.py lms createsuperuser`
4. When you have done `vagrant ssh` you need to change the user `sudo -u edxapp -Hs`
5. Clone this repository in appropriate location
6. Acvtivate the virtualenvironment `source /edx/app/edxapp/venvs/edxapp/bin/acitvate`
7. cd to `xblock-group-project-v2` and run `pip install -e`.
8. Now from 'edx-platfrom' run `paver devstack studio --fast` in one terminal and `paver devstack lms --fast` in another. 
if you face any issue mostly it is listed in [here](https://github.com/edx-solutions/edx-platform/wiki/Setting-up-the-solutions-devstack). 

You might get mongo db connection error to resolve that run 

```
$ sudo -u mongodb /usr/bin/mongod --repair --config /etc/mongod.conf
$ sudo systemctl restart mongod.service
```
Sign in to  lms and studio  and edit one of the demo courses. If you face anyissue here just sign in to `django admin` and pages will be accessible to you.

9.  Follow https://github.com/open-craft/xblock-group-project-v2/blob/master/docs/authoring.md#group-project-authoring-walkthrough to add `group-project-xblock`
10. When you will reach the `Peer Grading` step you will notice in your `studio` logs that you have started getting 
```
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/src/xblock-group-project-v2/group_project_v2/mixins.py", line 97, in user_id
    return int(self.real_user_id(self.anonymous_student_id))
  File "/edx/app/edxapp/venvs/edxapp/src/xblock-group-project-v2/group_project_v2/mixins.py", line 119, in real_user_id
    self._known_real_user_ids[anonymous_student_id] = self.runtime.get_real_user(anonymous_student_id).id
TypeError: 'NoneType' object is not callable
```

11. This happens mostly when you add `Review Question`
10. Uninstall the block using `pip uninstall ` check `pip freeze | grep group` to know which package to uninstall
11. cd to `xblock-group-project-v2`  and do `git fetch origin farhaan/bb-2920-suppressing-logs` then `git checkout farhaan/bb-2920-suppressing-logs`
12. Make sure the venv is activated and then do a `pip install -e`
13. You don't have to do any changes to the course now, just try to edit the `Review Question` you will see no logs are shown in studio now.


**Author notes and concerns**:

The change was simple but the test setup might take time to get up and running.

**Reviewers**
- [ ] @xitij2000 