### PR TITLE
MCKIN-28448 - Deliverables are not uploading

### DIFF
--- a/group_project_v2/json_requests.py
+++ b/group_project_v2/json_requests.py
@@ -60,7 +60,7 @@ def GET(url_path):
 def POST(url_path, data):
     """ POST request wrapper to json web server """
     url_request = Request(url=url_path, headers=json_headers())
-    return urlopen(url_request, json.dumps(data), TIMEOUT)
+    return urlopen(url_request, json.dumps(data).encode('utf-8'), TIMEOUT)
 
 
 @trace_request_information

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-group-project-v2',
-    version='0.12.9',
+    version='0.12.10',
     description='XBlock - Group Project V2',
     packages=find_packages(),
     install_requires=[


### PR DESCRIPTION
GW Deliverables upload fails with on Py3. 
```
group_project_v2/json_requests.py", line 63, in POST
edx.devstack-juniper.lms |     return urlopen(url_request, json.dumps(data), TIMEOUT)
edx.devstack-juniper.lms |   File "/usr/lib/python3.5/urllib/request.py", line 163, in urlopen
edx.devstack-juniper.lms |     return opener.open(url, data, timeout)
edx.devstack-juniper.lms |   File "/usr/lib/python3.5/urllib/request.py", line 464, in open
edx.devstack-juniper.lms |     req = meth(req)
edx.devstack-juniper.lms |   File "/usr/lib/python3.5/urllib/request.py", line 1190, in do_request_
edx.devstack-juniper.lms |     raise TypeError(msg)
edx.devstack-juniper.lms | TypeError: POST data should be bytes or an iterable of bytes. It cannot be of type str.
```
Converting str to btyes to fix that.