### PR TITLE
YONK-1854 'TypeError' object has no attribute 'message'.

### DIFF
--- a/group_project_v2/stage/basic.py
+++ b/group_project_v2/stage/basic.py
@@ -78,8 +78,8 @@ class CompletionStage(SimpleCompletionStageMixin, BaseGroupActivityStage):
                 'new_stage_states': [self.get_new_stage_state_data()]
             }
         except ApiError as exception:
-            log.exception(exception.message)
-            return {'result': 'error', 'msg': exception.message}
+            log.exception(str(exception))
+            return {'result': 'error', 'msg': str(exception)}
 
     def mark_complete(self, user_id=None):
         user_id = user_id or self.user_id

--- a/group_project_v2/stage/review.py
+++ b/group_project_v2/stage/review.py
@@ -191,10 +191,10 @@ class ReviewBaseStage(BaseGroupActivityStage):
             if self.can_mark_complete and self.review_status() == ReviewState.COMPLETED:
                 self.mark_complete()
         except ApiError as exception:
-            log.exception(exception.message)
+            log.exception(str(exception))
             return {
                 'result': 'error',
-                'msg': exception.message,
+                'msg': str(exception),
                 'error': exception.content_dictionary
             }
 

--- a/group_project_v2/utils.py
+++ b/group_project_v2/utils.py
@@ -207,7 +207,7 @@ def conversion_protected_handler(func):
         try:
             return func(*args, **kwargs)
         except (TypeError, ValueError) as exception:
-            message = "Conversion failed: {}".format(exception.message)
+            message = "Conversion failed: {}".format(str(exception))
             log.exception(message)
             return {'result': 'error', 'msg': message}
 

--- a/tests/unit/test_stage_components.py
+++ b/tests/unit/test_stage_components.py
@@ -297,7 +297,7 @@ class TestGroupProjectSubmissionXBlock(StageComponentXBlockTestBase):
                 self.block.persist_and_submit_file(self.stage_mock.activity, context_mock, uploaded_file)
                 exception = raises_cm.exception
                 expected_message = "Error storing file {} - {}".format(upload_file_mock.file.name, "some error")
-                self.assertEqual(exception.message, expected_message)
+                self.assertEqual(str(exception), expected_message)
 
             upload_file_mock.save_file.side_effect = lambda: 1
             upload_file_mock.submit = mock.Mock(side_effect=Exception("other error"))
@@ -308,7 +308,7 @@ class TestGroupProjectSubmissionXBlock(StageComponentXBlockTestBase):
                 expected_message = "Error recording file information {} - {}".format(
                     upload_file_mock.file.name, "other error"
                 )
-                self.assertEqual(exception.message, expected_message)
+                self.assertEqual(str(exception), expected_message)
 
     @ddt.data(1, "upload 12", "iddqd")
     def test_persist_and_submit_file_success_path(self, upload_id):


### PR DESCRIPTION
`Stack trace
builtins:AttributeError: 'TypeError' object has no attribute 'message'
Traceback(most recent call last):
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/django/utils/deprecation.py", line 94, in __call__
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/newrelic/hooks/framework_django.py", line 1184, in _wrapper
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/django/core/handlers/exception.py", line 34, in inner
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/django/utils/deprecation.py", line 94, in __call__
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/newrelic/hooks/framework_django.py", line 1184, in _wrapper
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/django/core/handlers/exception.py", line 34, in inner
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/django/utils/deprecation.py", line 94, in __call__
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/newrelic/hooks/framework_django.py", line 1184, in _wrapper
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/django/core/handlers/exception.py", line 34, in inner
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/django/utils/deprecation.py", line 94, in __call__
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/newrelic/hooks/framework_django.py", line 1184, in _wrapper
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/django/core/handlers/exception.py", line 34, in inner
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/django/utils/deprecation.py", line 94, in __call__
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/newrelic/hooks/framework_django.py", line 1184, in _wrapper
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/django/core/handlers/exception.py", line 34, in inner
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/django/utils/deprecation.py", line 94, in __call__
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/newrelic/hooks/framework_django.py", line 1184, in _wrapper
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/django/core/handlers/exception.py", line 34, in inner
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/django/utils/deprecation.py", line 94, in __call__
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/newrelic/hooks/framework_django.py", line 1184, in _wrapper
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/django/core/handlers/exception.py", line 34, in inner
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/django/utils/deprecation.py", line 94, in __call__
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/newrelic/hooks/framework_django.py", line 1184, in _wrapper
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/django/core/handlers/exception.py", line 34, in inner
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/django/utils/deprecation.py", line 94, in __call__
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/newrelic/hooks/framework_django.py", line 1184, in _wrapper
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/django/core/handlers/exception.py", line 34, in inner
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/django/utils/deprecation.py", line 94, in __call__
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/newrelic/hooks/framework_django.py", line 1184, in _wrapper
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/django/core/handlers/exception.py", line 34, in inner
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/django/utils/deprecation.py", line 94, in __call__
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/newrelic/hooks/framework_django.py", line 1184, in _wrapper
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/django/core/handlers/exception.py", line 34, in inner
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/django/utils/deprecation.py", line 94, in __call__
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/newrelic/hooks/framework_django.py", line 1184, in _wrapper
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/django/core/handlers/exception.py", line 34, in inner
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/django/core/handlers/base.py", line 115, in _get_response
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/django/core/handlers/base.py", line 113, in _get_response
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/newrelic/hooks/framework_django.py", line 540, in wrapper
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/django/views/decorators/clickjacking.py", line 50, in wrapped_view
File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/module_render.py", line 1107, in handle_xblock_callback
File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/module_render.py", line 1232, in _invoke_xblock_handler
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/xblock/mixins.py", line 89, in handle
File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 1450, in handle
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/xblock/runtime.py", line 1063, in handle
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/xblock/mixins.py", line 68, in wrapper
File "/edx/app/edxapp/venvs/edxapp/src/xblock-group-project-v2/group_project_v2/utils.py", line 182, in wrapper
File "/edx/app/edxapp/venvs/edxapp/src/xblock-group-project-v2/group_project_v2/utils.py", line 196, in wrapper
File "/edx/app/edxapp/venvs/edxapp/src/xblock-group-project-v2/group_project_v2/utils.py", line 210, in wrapper`