### PR TITLE
MCKIN-28362 - Encoding and exception formatting fixed

### DIFF
--- a/group_project_v2/json_requests.py
+++ b/group_project_v2/json_requests.py
@@ -76,6 +76,6 @@ def DELETE(url_path):
 def PUT(url_path, data):
     """ PUT request wrapper to json web server """
     opener = build_opener(HTTPHandler)
-    request = Request(url=url_path, headers=json_headers(), data=json.dumps(data))
+    request = Request(url=url_path, headers=json_headers(), data=json.dumps(data).encode('utf-8'))
     request.get_method = lambda: 'PUT'
     return opener.open(request, None, TIMEOUT)

--- a/group_project_v2/utils.py
+++ b/group_project_v2/utils.py
@@ -146,7 +146,7 @@ def mean(value_array):
         numeric_values = [float(v) for v in value_array]
         return float(sum(numeric_values) / len(numeric_values))
     except (ValueError, TypeError, ZeroDivisionError) as exc:
-        log.warning(exc.message)
+        log.warning(exc)
         return None
 
 
@@ -183,7 +183,7 @@ def groupwork_protected_handler(func):
         except GroupworkAccessDeniedError as exc:
             return {
                 'result': 'error',
-                'message': exc.message
+                'message': str(exc)
             }
 
     return wrapper
@@ -207,7 +207,7 @@ def conversion_protected_handler(func):
         try:
             return func(*args, **kwargs)
         except (TypeError, ValueError) as exception:
-            message = "Conversion failed: {}".format(exception.message)
+            message = "Conversion failed: {}".format(exception)
             log.exception(message)
             return {'result': 'error', 'msg': message}
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-group-project-v2',
-    version='0.12.12',
+    version='0.12.11',
     description='XBlock - Group Project V2',
     packages=find_packages(),
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-group-project-v2',
-    version='0.12.11',
+    version='0.12.12',
     description='XBlock - Group Project V2',
     packages=find_packages(),
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-group-project-v2',
-    version='0.12.10',
+    version='0.12.11',
     description='XBlock - Group Project V2',
     packages=find_packages(),
     install_requires=[


### PR DESCRIPTION
This fixes PUT data encoding and exceptions messages:

```
t_v2/json_requests.py", line 39, in make_request
edx.devstack-juniper.lms |     response = func(*args, **kwargs)
edx.devstack-juniper.lms |   File "/edx/src/xblock-group-project-v2/group_project_v2/json_requests.py", line 81, in PUT
edx.devstack-juniper.lms |     return opener.open(request, None, TIMEOUT)
edx.devstack-juniper.lms |   File "/usr/lib/python3.5/urllib/request.py", line 464, in open
edx.devstack-juniper.lms |     req = meth(req)
edx.devstack-juniper.lms |   File "/usr/lib/python3.5/urllib/request.py", line 1190, in do_request_
edx.devstack-juniper.lms |     raise TypeError(msg)
edx.devstack-juniper.lms | TypeError: POST data should be bytes or an iterable of bytes. It cannot be of type str.
edx.devstack-juniper.lms | 
```

```
During handling of the above exception, another exception occurred:
edx.devstack-juniper.lms | 

edx.devstack-juniper.lms |   File "/edx/src/xblock-group-project-v2/group_project_v2/utils.py", line 182, in wrapper
edx.devstack-juniper.lms |     return func(*args, **kwargs)
edx.devstack-juniper.lms |   File "/edx/src/xblock-group-project-v2/group_project_v2/utils.py", line 196, in wrapper
edx.devstack-juniper.lms |     return func(*args, **kwargs)
edx.devstack-juniper.lms |   File "/edx/src/xblock-group-project-v2/group_project_v2/utils.py", line 210, in wrapper
edx.devstack-juniper.lms |     message = "Conversion failed: {}".format(exception.message)
edx.devstack-juniper.lms | AttributeError: 'TypeError' object has no attribute 'message'
```
